### PR TITLE
ci: switch self-hosted runners from Oracle to CNCF Ubuntu

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,8 +1,8 @@
 self-hosted-runner:
   labels:
-    - oracle-vm-2cpu-8gb-x86-64
-    - oracle-vm-4cpu-16gb-x86-64
-    - oracle-vm-8cpu-32gb-x86-64
-    - oracle-vm-16cpu-64gb-x86-64
-    - oracle-vm-24cpu-96gb-x86-64
-    - oracle-vm-32cpu-128gb-x86-64
+    - cncf-ubuntu-2-8-x86
+    - cncf-ubuntu-4-16-x86
+    - cncf-ubuntu-8-32-x86
+    - cncf-ubuntu-16-64-x86
+    - cncf-ubuntu-24-96-x86
+    - cncf-ubuntu-32-128-x86

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           filters: .github/filters.yaml
 
   validate:
-    runs-on: oracle-vm-4cpu-16gb-x86-64
+    runs-on: cncf-ubuntu-4-16-x86
     timeout-minutes: 45
     container:
       image: quay.io/libpod/skopeo_cidev:c20260310t170224z-f43f42d14 # FIXME: Should be Renovate-managed.
@@ -49,7 +49,7 @@ jobs:
 
   doccheck:
     needs: validate
-    runs-on: oracle-vm-4cpu-16gb-x86-64
+    runs-on: cncf-ubuntu-4-16-x86
     timeout-minutes: 45
     container:
       image: quay.io/libpod/skopeo_cidev:c20260310t170224z-f43f42d14 # FIXME: Should be Renovate-managed.
@@ -118,7 +118,7 @@ jobs:
     if: >-
       !contains(github.event.pull_request.title || github.event.head_commit.message, '[CI:DOCS]')
       && !contains(github.event.pull_request.title || github.event.head_commit.message, '[CI:BUILD]')
-    runs-on: oracle-vm-2cpu-8gb-x86-64
+    runs-on: cncf-ubuntu-2-8-x86
     timeout-minutes: 45
     name: test_skopeo / ${{ matrix.name }}
     strategy:
@@ -156,7 +156,7 @@ jobs:
       && (github.event_name != 'pull_request'
           || needs.path-filter.outputs.all == 'true'
           || needs.path-filter.outputs.code == 'true')
-    runs-on: oracle-vm-4cpu-16gb-x86-64
+    runs-on: cncf-ubuntu-4-16-x86
     timeout-minutes: 45
     container:
       image: quay.io/coreos-assembler/fcos-buildroot:testing-devel


### PR DESCRIPTION
The Oracle VM runners are discouraged to used by CNCF. using CNCF-* runners