### PR TITLE
inspect: add Comment field to inspect output

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -178,6 +178,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 		Layers:        imgInspect.Layers,
 		LayersData:    imgInspect.LayersData,
 		Env:           imgInspect.Env,
+		Comment:       imgInspect.Comment,
 	}
 	outputData.Digest, err = manifestDigestFromManifest(rawManifest, img, opts.manifestDigest)
 	if err != nil {

--- a/cmd/skopeo/inspect/output.go
+++ b/cmd/skopeo/inspect/output.go
@@ -22,4 +22,5 @@ type Output struct {
 	Layers        []string
 	LayersData    []types.ImageInspectLayer
 	Env           []string
+	Comment       string
 }

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -138,7 +138,8 @@ $ skopeo inspect docker://docker.io/fedora
         "DISTTAG=f37container",
         "FGC=f37",
         "FBR=f37"
-    ]
+    ],
+    "Comment": "some comment"
 }
 ```
 

--- a/vendor/go.podman.io/image/v5/manifest/docker_schema1.go
+++ b/vendor/go.podman.io/image/v5/manifest/docker_schema1.go
@@ -253,6 +253,7 @@ func (m *Schema1) Inspect(_ func(types.BlobInfo) ([]byte, error)) (*types.ImageI
 		Layers:        layerInfosToStrings(layerInfos),
 		LayersData:    imgInspectLayersFromLayerInfos(layerInfos),
 		Author:        s1.Author,
+		Comment:       s1.Comment,
 	}
 	if s1.Config != nil {
 		i.Labels = s1.Config.Labels

--- a/vendor/go.podman.io/image/v5/manifest/docker_schema2.go
+++ b/vendor/go.podman.io/image/v5/manifest/docker_schema2.go
@@ -272,6 +272,10 @@ func (m *Schema2) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*t
 		return nil, err
 	}
 	layerInfos := m.LayerInfos()
+	comment := s2.Comment
+	if len(comment) == 0 && len(s2.History) > 0 {
+		comment = s2.History[len(s2.History)-1].Comment
+	}
 	i := &types.ImageInspectInfo{
 		Tag:           "",
 		Created:       &s2.Created,
@@ -282,6 +286,7 @@ func (m *Schema2) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*t
 		Layers:        layerInfosToStrings(layerInfos),
 		LayersData:    imgInspectLayersFromLayerInfos(layerInfos),
 		Author:        s2.Author,
+		Comment:       comment,
 	}
 	if s2.Config != nil {
 		i.Labels = s2.Config.Labels

--- a/vendor/go.podman.io/image/v5/manifest/oci.go
+++ b/vendor/go.podman.io/image/v5/manifest/oci.go
@@ -219,6 +219,10 @@ func (m *OCI1) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*type
 	if err := json.Unmarshal(config, d1); err != nil {
 		return nil, err
 	}
+	comment := d1.Comment
+	if len(v1.History) > 0 && len(comment) == 0 {
+		comment = v1.History[len(v1.History)-1].Comment
+	}
 	layerInfos := m.LayerInfos()
 	i := &types.ImageInspectInfo{
 		Tag:           "",
@@ -232,6 +236,7 @@ func (m *OCI1) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*type
 		LayersData:    imgInspectLayersFromLayerInfos(layerInfos),
 		Env:           v1.Config.Env,
 		Author:        v1.Author,
+		Comment:       comment,
 	}
 	return i, nil
 }

--- a/vendor/go.podman.io/image/v5/types/types.go
+++ b/vendor/go.podman.io/image/v5/types/types.go
@@ -487,6 +487,7 @@ type ImageInspectInfo struct {
 	LayersData    []ImageInspectLayer
 	Env           []string
 	Author        string
+	Comment       string
 }
 
 // ImageInspectLayer is a set of metadata describing an image layers' detail


### PR DESCRIPTION
Expose the Comment field from the image configuration in the skopeo inspect JSON output. Previously, the Comment field was available via 'podman inspect' but not via 'skopeo inspect'.

Closes #2098