### PR TITLE
ci: drop build + install from doccheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,6 @@ jobs:
           persist-credentials: false
       - name: fix git safe.directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: remove pre-installed skopeo package
-        run: dnf remove -y skopeo
-      - name: build + install
-        run: |
-          make BUILDTAGS=containers_image_openpgp bin/skopeo
-          make BUILDTAGS=containers_image_openpgp install PREFIX=/usr/local
       - run: make BUILDTAGS=containers_image_openpgp validate-docs
 
   cross:


### PR DESCRIPTION
Following on from the other CI cleanup issues. I went and checked whether the doccheck job actually needs the install, since the issue said it should be fine without it.

validate-docs already lists bin/skopeo as a prerequisite in the Makefile, so make bin/skopeo just builds it a second time. And neither of the two checks it runs looks at PATH - man-page-checker calls ../bin/$cmd from the docs dir, and xref-helpmsgs-manpages defaults SKOPEO to ./bin/skopeo. So installing into /usr/local and pulling the packaged skopeo out first were not feeding either of them.

That leaves the job as just the validate-docs line.

One thing worth flagging, #2885 also touches this job, though the safe.directory step rather than these ones, so it might want a rebase depending on which lands first.

Closes: #2922