### PR TITLE
ci: don't cancel overlapping runs on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   # CI automation repo release for the VM image downloads in ci.sh.


### PR DESCRIPTION
## Description

Currently, `cancel-in-progress: true` applies to both pull request runs and pushes to `main`.

When multiple commits are pushed to `main` in quick succession, an in-progress CI run for an earlier merge commit can be cancelled by a newer push. This prevents the post-merge CI result from being available for every merge commit.

This change makes in-progress cancellation conditional on the event type:

* Pull request runs continue to cancel when superseded by a newer commit.
* Pushes to `main` are allowed to run to completion.

This preserves the existing optimization for PR CI while ensuring post-merge CI runs on `main` are not cancelled by subsequent pushes.

## Testing

* `git diff --check` — passed
* Reviewed the workflow triggers and concurrency configuration

Fixes #2918
