### PR TITLE
Packit config update to skip TF jobs for unavailable composes and Fedora-45 downstream addition.

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -124,6 +124,7 @@ jobs:
     update_release: false
     dist_git_branches: &fedora_targets
       - fedora-rawhide
+      - fedora-45
     actions:
         post-modifications: >-
           bash -c 'sed -i "s/^\(\s*\)ref: .*/\1ref: v${PACKIT_PROJECT_VERSION}/" ${PACKIT_DOWNSTREAM_REPO}/plans/main.fmf'

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -78,6 +78,7 @@ jobs:
   - job: tests
     trigger: pull_request
     packages: [skopeo-fedora]
+    skip_missing_branched_composes: true
     notifications: &test_failure_notification
       failure_comment:
         message: "Tests failed. @containers/packit-build please check."


### PR DESCRIPTION
See individual commits.

Refs:
https://github.com/packit/packit-service/issues/2992
https://github.com/podman-container-tools/podman/pull/29383