### PR TITLE
docs: add override-os and override-arch example to inspect --help

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -54,7 +54,8 @@ See skopeo(1) section "IMAGE NAMES" for the expected format
 		RunE: commandAction(opts.run),
 		Example: `skopeo inspect docker://registry.fedoraproject.org/fedora
 skopeo inspect --config docker://docker.io/alpine
-skopeo inspect --format "Name: {{.Name}} Digest: {{.Digest}}" docker://registry.access.redhat.com/ubi8`,
+skopeo inspect --format "Name: {{.Name}} Digest: {{.Digest}}" docker://registry.access.redhat.com/ubi8
+skopeo inspect --override-os linux --override-arch amd64 docker://docker.io/library/alpine`,
 		ValidArgsFunction: autocompleteImageNames,
 	}
 	adjustUsage(cmd)


### PR DESCRIPTION
Adds an example to skopeo inspect --help showing --override-os and --override-arch together. Closes #2793. The flags already existed and were in the man page, someone hit the exact case in the issue where their client architecture did not match the image and had no way to know from --help alone how to fix it. mtrmac proposed this exact fix in the issue thread. No behavior change, one line added to the existing Example string, checked that it builds and that the new line shows up correctly in skopeo inspect --help output.