### PR TITLE
update Maintainers and Governance to link to community repo

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,11 +1,3 @@
-## The Skopeo Project Community Governance
+# Project Governance
 
-The Skopeo project, as part of Podman Container Tools, follows the [Podman Project Governance](https://github.com/containers/podman/blob/main/GOVERNANCE.md)
-except sections found in this document, which override those found in Podman's Governance.
-
----
-
-# Maintainers File
-
-The definitive source of truth for maintainers of this repository is the local [MAINTAINERS.md](./MAINTAINERS.md) file. The [MAINTAINERS.md](https://github.com/containers/podman/blob/main/MAINTAINERS.md) file in the main Podman repository is used for project-spanning roles, including Core Maintainer and Community Manager.
-
+The Skopeo tool, as part of the [Podman Container Tools project](https://www.cncf.io/projects/podman-container-tools), follows the project's governance, which is defined here: https://github.com/podman-container-tools/community/blob/main/GOVERNANCE.md

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,26 +1,22 @@
 # Skopeo Maintainers
 
-[GOVERNANCE.md](https://github.com/containers/podman/blob/main/GOVERNANCE.md)
-describes the project's governance and the Project Roles used below.
+[GOVERNANCE.md](https://github.com/podman-container-tools/community/blob/main/GOVERNANCE.md)
+describes the Podman Container Tools project's governance and the Project Roles used below.
+
+Please note that this file only includes Skopeo's Maintainers and Reviewers.
+Core Maintainers and Community Managers who act on the behalf of all repositories are only defined in the community repository's [MAINTAINERS.md](https://github.com/podman-container-tools/community/blob/main/MAINTAINERS.md) file.
+Maintainers and Reviewers on other Podman Container Tools projects are found in their respective repository's MAINTAINERS.md files.
 
 ## Maintainers
 
-| Maintainer        | GitHub ID                                                | Project Roles                    | Affiliation                                  |
-|-------------------|----------------------------------------------------------|----------------------------------|----------------------------------------------|
-| Brent Baude       | [baude](https://github.com/baude)                        | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
-| Nalin Dahyabhai   | [nalind](https://github.com/nalind)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
-| Matthew Heon      | [mheon](https://github.com/mheon)                        | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
-| Paul Holzinger    | [Luap99](https://github.com/Luap99)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
-| Giuseppe Scrivano | [giuseppe](https://github.com/giuseppe)                  | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
-| Miloslav Trmač    | [mtrmac](https://github.com/mtrmac)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
-| Mohan Boddu       | [mohanboddu](https://github.com/mohanboddu)              | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
-| Neil Smith        | [actionmancan](https://github.com/actionmancan)          | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
-| Tom Sweeney       | [TomSweeneyRedHat](https://github.com/TomSweeneyRedHat/) | Maintainer and Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
-| Lokesh Mandvekar  | [lsm5](https://github.com/lsm5)                          | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
-| Dan Walsh         | [rhatdan](https://github.com/rhatdan)                    | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
-| Ashley Cui        | [ashley-cui](https://github.com/ashley-cui)              | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
-| Valentin Rothberg | [vrothberg](https://github.com/vrothberg)                | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
-| Colin Walters     | [cgwalters](https://github.com/cgwalters)                | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+| Maintainer        | GitHub ID                                                | Project Roles | Affiliation                                  |
+| ----------------- | -------------------------------------------------------- | ------------- | -------------------------------------------- |
+| Lokesh Mandvekar  | [lsm5](https://github.com/lsm5)                          | Maintainer    | [Red Hat](https://github.com/RedHatOfficial) |
+| Tom Sweeney       | [TomSweeneyRedHat](https://github.com/TomSweeneyRedHat/) | Maintainer    | [Red Hat](https://github.com/RedHatOfficial) |
+| Dan Walsh         | [rhatdan](https://github.com/rhatdan)                    | Maintainer    | [Red Hat](https://github.com/RedHatOfficial) |
+| Ashley Cui        | [ashley-cui](https://github.com/ashley-cui)              | Reviewer      | [Red Hat](https://github.com/RedHatOfficial) |
+| Valentin Rothberg | [vrothberg](https://github.com/vrothberg)                | Reviewer      | [Red Hat](https://github.com/RedHatOfficial) |
+| Colin Walters     | [cgwalters](https://github.com/cgwalters)                | Reviewer      | [Red Hat](https://github.com/RedHatOfficial) |
 
 ## Alumni
 
@@ -29,7 +25,3 @@ None at present
 ## Credits
 
 The structure of this document was based off of the equivalent one in the [CRI-O Project](https://github.com/cri-o/cri-o/blob/main/MAINTAINERS.md).
-
-## Note
-
-If there is a discrepancy between the [MAINTAINERS.md](https://github.com/containers/podman/blob/main/MAINTAINERS.md) file in the main Podman repository and this file regarding Core Maintainers or Community Managers, the file in the Podman Repository is considered the source of truth.


### PR DESCRIPTION
With the new community repo we use that as place to define our Governance and the org wide rules. As such we should just link there to avoid duplication and drift.