### PR TITLE
ci: add zizmor workflow

### DIFF
--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -15,7 +15,12 @@ jobs:
   # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
   closed_issue_discussion_lock:
     uses: podman-container-tools/podman/.github/workflows/issue_pr_lock.yml@main
-    secrets: inherit
+    secrets:
+      STALE_LOCKING_APP_PRIVATE_KEY: ${{ secrets.STALE_LOCKING_APP_PRIVATE_KEY }}
+      ACTION_MAIL_SERVER: ${{ secrets.ACTION_MAIL_SERVER }}
+      ACTION_MAIL_USERNAME: ${{ secrets.ACTION_MAIL_USERNAME }}
+      ACTION_MAIL_PASSWORD: ${{ secrets.ACTION_MAIL_PASSWORD }}
+      ACTION_MAIL_SENDER: ${{ secrets.ACTION_MAIL_SENDER }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: 'zizmor: GitHub Actions Security Analysis'
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write # to create vulnerability alerts
+      contents: read # to read repo contents
+      actions: read # to read GitHub actions info
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2


### PR DESCRIPTION
Same zizmor.yml podman runs on main, byte for byte.

I ran zizmor 1.16.3 over the three existing workflows before opening this so there are no surprises on the first run:

```
warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> .github/workflows/issue_pr_lock.yml:17:5

24 findings (23 suppressed): 0 informational, 0 low, 1 medium, 0 high
```

The action uploads SARIF to code scanning and does not fail the job on findings, so nothing here can block CI.

Fixes: #2913
cc @timcoding1988 cc @Luap99 