### PR TITLE
hack: fix validate-git-marks.sh never detecting conflict markers

### DIFF
--- a/hack/validate-git-marks.sh
+++ b/hack/validate-git-marks.sh
@@ -6,11 +6,9 @@ unset IFS
 
 badFiles=()
 for f in "${files[@]}"; do
-    if [ $(grep -r "^\(<<<<<<<\|>>>>>>>\|^=======$\)" $f) ]; then
+    if grep -Eq '^(<<<<<<<|>>>>>>>|=======$)' "$f"; then
         badFiles+=( "$f" )
-        continue
     fi
-    set -e
 done
 
 


### PR DESCRIPTION
Fixes: #2953


The script tested grep's output instead of its exit status:

```bash
if [ $(grep -r "^\(<<<<<<<\|>>>>>>>\|^=======$\)" $f) ]; then
```

Git writes markers with a label (`<<<<<<< HEAD`), so `[` got two or more arguments, failed
with "too many arguments" and exited non-zero — the file was never flagged. On a repo with a
committed conflict the script printed "Congratulations!  There is no conflict." and exited 0.

Now tests the exit status with `grep -Eq` and quotes `"$f"`. Dropped `-r`, meaningless on a
regular file, plus the `continue` and the dead `set -e` — the script has no `set -e` at the
top and no `set +e`.

Semantics unchanged: `<<<<<<<` and `>>>>>>>` match as line prefixes, `=======` only as a whole
line. The single grep from `aebab492` is kept; only the test around it changes.

Verified: planted conflict now exits 1 and names the file (was rc=0); each marker type
detected on its own; `======= section header` still not flagged; this tree still passes clean;


