### PR TITLE
hack: fix man-page-checker synopsis check on non-GNU sed

### DIFF
--- a/hack/man-page-checker
+++ b/hack/man-page-checker
@@ -98,7 +98,9 @@ function compare_usage() {
 
     # Args in man page are '_foo_', in --help are 'FOO'. Convert all to
     # UPCASE simply because it stands out better to the eye.
-    from_man=$(sed -E -e 's/_([a-z-]+)_/\U\1/g' <<<"$from_man")
+    # Use perl, not sed: \U is a GNU sed extension, and BSD sed (macOS)
+    # substitutes a literal 'U' instead.
+    from_man=$(perl -pe 's/_([a-z-]+)_/\U$1/g' <<<"$from_man")
 
     # Compare man-page and --help usage strings. Skip 'skopeo' itself,
     # because the man page includes '[global options]' which we don't grok.


### PR DESCRIPTION
Fixed: #2956

`\U` in the argument-uppercasing sed is a GNU extension. BSD sed substitutes a literal `U`,
so every SYNOPSIS vs `--help` comparison mismatched and `make validate-docs` failed on macOS
with 11 bogus errors.

Swapped to perl, where `\U` is native syntax. No new dependency — `validate-docs` already
runs `hack/xref-helpmsgs-manpages`, which is a perl script.

Verified on macOS: 11 errors and rc=1 before, rc=0 after; `xref-helpmsgs-manpages` still
rc=0; shellcheck unchanged.
