### PR TITLE
RFC: Start using log/slog as the primary logging mechanism

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.podman.io/common/pkg/report"
 	"go.podman.io/common/pkg/retry"
@@ -214,7 +214,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 			if fatalFailure {
 				return fmt.Errorf("Error determining repository tags: %w", err)
 			}
-			logrus.Warnf("Registry disallows tag list retrieval; skipping")
+			slog.Warn("Registry disallows tag list retrieval; skipping")
 		}
 	}
 	return opts.writeOutput(stdout, outputData)

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -166,7 +166,7 @@ func main() {
 
 	rootCmd, _ := createApp()
 	if err := rootCmd.Execute(); err != nil {
-		slog.Error(err.Error())
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		if isNotFoundImageError(err) {
 			os.Exit(2)
 		}

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -3,11 +3,16 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
+	"log/slog"
+	"os"
 	"runtime/debug"
 	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
 	"github.com/spf13/cobra"
 	commonFlag "go.podman.io/common/pkg/flag"
 	"go.podman.io/image/v5/pkg/cli/basetls/tlsdetails"
@@ -15,6 +20,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/skopeo/version"
 	"go.podman.io/storage/pkg/reexec"
+	"golang.org/x/term"
 )
 
 var defaultUserAgent = "skopeo/" + version.Version
@@ -136,6 +142,7 @@ func gitCommit() string {
 func (opts *globalOptions) before(cmd *cobra.Command, args []string) error {
 	if opts.debug {
 		logrus.SetLevel(logrus.DebugLevel)
+		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
 	if opts.tlsVerify.Present() {
 		logrus.Warn("'--tls-verify' is deprecated, please set this on the specific subcommand")
@@ -150,13 +157,20 @@ func main() {
 	if reexec.Init() {
 		return
 	}
+
+	logrus.SetOutput(io.Discard)
+	logrus.AddHook(lslog.NewHook(slog.Default(), nil))
+	if term.IsTerminal(int(os.Stderr.Fd())) {
+		log.SetFlags(0) // We don’t want date/time in interactive output
+	}
+
 	rootCmd, _ := createApp()
 	if err := rootCmd.Execute(); err != nil {
+		slog.Error(err.Error())
 		if isNotFoundImageError(err) {
-			logrus.StandardLogger().Log(logrus.FatalLevel, err)
-			logrus.Exit(2)
+			os.Exit(2)
 		}
-		logrus.Fatal(err)
+		os.Exit(1)
 	}
 }
 

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -99,7 +99,7 @@ func createApp() (*cobra.Command, *globalOptions) {
 	rootCommand.PersistentFlags().DurationVar(&opts.commandTimeout, "command-timeout", 0, "timeout for the command execution (e.g. 30s, 10m)")
 	rootCommand.PersistentFlags().StringVar(&opts.registriesConfPath, "registries-conf", "", "path to the registries.conf file")
 	if err := rootCommand.PersistentFlags().MarkHidden("registries-conf"); err != nil {
-		logrus.Fatal("unable to mark registries-conf flag as hidden")
+		panic("unable to mark registries-conf flag as hidden")
 	}
 	rootCommand.PersistentFlags().StringVar(&opts.tmpDir, "tmpdir", "", "directory used to store temporary files")
 	rootCommand.PersistentFlags().StringVar(&opts.userAgentPrefix, "user-agent-prefix", "", "prefix to add to the user agent string")
@@ -128,7 +128,7 @@ func createApp() (*cobra.Command, *globalOptions) {
 func gitCommit() string {
 	bi, ok := debug.ReadBuildInfo()
 	if !ok {
-		logrus.Fatal("runtime.ReadBuildInfo failed")
+		panic("runtime.ReadBuildInfo failed")
 	}
 	for _, e := range bi.Settings {
 		if e.Key == "vcs.revision" {
@@ -145,7 +145,7 @@ func (opts *globalOptions) before(cmd *cobra.Command, args []string) error {
 		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
 	if opts.tlsVerify.Present() {
-		logrus.Warn("'--tls-verify' is deprecated, please set this on the specific subcommand")
+		slog.Warn("'--tls-verify' is deprecated, please set this on the specific subcommand")
 	}
 	if opts.insecurePolicy && opts.requireSigned {
 		return fmt.Errorf("--insecure-policy and --require-signed are mutually exclusive")

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -15,7 +16,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.podman.io/common/pkg/retry"
 	"go.podman.io/image/v5/copy"
@@ -189,7 +189,7 @@ func destinationReference(destination string, transport string) (types.ImageRefe
 	default:
 		return nil, fmt.Errorf("%q is not a valid destination transport", transport)
 	}
-	logrus.Debugf("Destination for transport %q: %s", transport, destination)
+	slog.Debug("Destination resolved", "transport", transport, "destination", destination)
 
 	destRef, err := imageTransport.ParseReference(destination)
 	if err != nil {
@@ -203,9 +203,7 @@ func destinationReference(destination string, transport string) (types.ImageRefe
 // It returns a string slice of tags and any error encountered.
 func getImageTags(ctx context.Context, sysCtx *types.SystemContext, repoRef reference.Named) ([]string, error) {
 	name := repoRef.Name()
-	logrus.WithFields(logrus.Fields{
-		"image": name,
-	}).Info("Getting tags")
+	slog.Info("Getting tags", "image", name)
 	// Ugly: NewReference rejects IsNameOnly references, and GetRepositoryTags ignores the tag/digest.
 	// So, we use TagNameOnly here only to shut up NewReference
 	dockerRef, err := docker.NewReference(reference.TagNameOnly(repoRef))
@@ -234,10 +232,7 @@ func imagesToCopyFromRepo(sys *types.SystemContext, repoRef reference.Named) ([]
 	for _, tag := range tags {
 		taggedRef, err := reference.WithTag(repoRef, tag)
 		if err != nil {
-			logrus.WithFields(logrus.Fields{
-				"repo": repoRef.Name(),
-				"tag":  tag,
-			}).Errorf("Error creating a tagged reference from registry tag list: %v", err)
+			slog.Error("Error creating a tagged reference from registry tag list", "err", err, "repo", repoRef.Name(), "tag", tag)
 			continue
 		}
 		ref, err := docker.NewReference(taggedRef)
@@ -299,21 +294,15 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 	var repoDescList []repoDescriptor
 
 	if len(cfg.Images) == 0 && len(cfg.ImagesByTagRegex) == 0 && len(cfg.ImagesBySemver) == 0 {
-		logrus.WithFields(logrus.Fields{
-			"registry": registryName,
-		}).Warn("No images specified for registry")
+		slog.Warn("No images specified for registry", "registry", registryName)
 		return repoDescList, nil
 	}
 
 	for imageName, refs := range cfg.Images {
-		repoLogger := logrus.WithFields(logrus.Fields{
-			"repo":     imageName,
-			"registry": registryName,
-		})
+		repoLogger := slog.With("repo", imageName, "registry", registryName)
 		repoRef, err := parseRepositoryReference(fmt.Sprintf("%s/%s", registryName, imageName))
 		if err != nil {
-			repoLogger.Error("Error parsing repository name, skipping")
-			logrus.Error(err)
+			repoLogger.Error("Error parsing repository name, skipping", "err", err)
 			continue
 		}
 
@@ -322,30 +311,27 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 		var sourceReferences []types.ImageReference
 		if len(refs) != 0 {
 			for _, ref := range refs {
-				tagLogger := logrus.WithFields(logrus.Fields{"ref": ref})
+				tagLogger := slog.With("ref", ref)
 				var named reference.Named
 				// first try as digest
 				if d, err := digest.Parse(ref); err == nil {
 					named, err = reference.WithDigest(repoRef, d)
 					if err != nil {
-						tagLogger.Error("Error processing ref, skipping")
-						logrus.Error(err)
+						tagLogger.Error("Error processing ref, skipping", "err", err)
 						continue
 					}
 				} else {
-					tagLogger.Debugf("Ref was not a digest, trying as a tag: %s", err)
+					tagLogger.Debug("Ref was not a digest, trying as a tag", "err", err)
 					named, err = reference.WithTag(repoRef, ref)
 					if err != nil {
-						tagLogger.Error("Error parsing ref, skipping")
-						logrus.Error(err)
+						tagLogger.Error("Error parsing ref, skipping", "err", err)
 						continue
 					}
 				}
 
 				imageRef, err := docker.NewReference(named)
 				if err != nil {
-					tagLogger.Error("Error processing ref, skipping")
-					logrus.Errorf("Error getting image reference: %s", err)
+					tagLogger.Error("Error processing ref, skipping", "err", err)
 					continue
 				}
 				sourceReferences = append(sourceReferences, imageRef)
@@ -354,14 +340,13 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 			repoLogger.Info("Querying registry for image tags")
 			sourceReferences, err = imagesToCopyFromRepo(serverCtx, repoRef)
 			if err != nil {
-				repoLogger.Error("Error processing repo, skipping")
-				logrus.Error(err)
+				repoLogger.Error("Error processing repo, skipping", "err", err)
 				continue
 			}
 		}
 
 		if len(sourceReferences) == 0 {
-			repoLogger.Warnf("No refs to sync found")
+			repoLogger.Warn("No refs to sync found")
 			continue
 		}
 		repoDescList = append(repoDescList, repoDescriptor{
@@ -374,7 +359,7 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 	{
 		filterCollection, err := tagRegexFilterCollection(cfg.ImagesByTagRegex)
 		if err != nil {
-			logrus.Error(err)
+			slog.Error(err.Error())
 		} else {
 			additionalRepoDescList := filterSourceReferences(serverCtx, registryName, filterCollection)
 			repoDescList = append(repoDescList, additionalRepoDescList...)
@@ -385,7 +370,7 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 	{
 		filterCollection, err := semverFilterCollection(cfg.ImagesBySemver)
 		if err != nil {
-			logrus.Error(err)
+			slog.Error(err.Error())
 		} else {
 			additionalRepoDescList := filterSourceReferences(serverCtx, registryName, filterCollection)
 			repoDescList = append(repoDescList, additionalRepoDescList...)
@@ -397,7 +382,7 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 
 // filterFunc is a function used to limit the initial set of image references
 // using tags, patterns, semver, etc.
-type filterFunc func(*logrus.Entry, types.ImageReference) bool
+type filterFunc func(*slog.Logger, types.ImageReference) bool
 
 // filterCollection is a map of repository names to filter functions.
 type filterCollection map[string]filterFunc
@@ -408,15 +393,11 @@ type filterCollection map[string]filterFunc
 func filterSourceReferences(sys *types.SystemContext, registryName string, collection filterCollection) []repoDescriptor {
 	var repoDescList []repoDescriptor
 	for repoName, filter := range collection {
-		logger := logrus.WithFields(logrus.Fields{
-			"repo":     repoName,
-			"registry": registryName,
-		})
+		logger := slog.With("repo", repoName, "registry", registryName)
 
 		repoRef, err := parseRepositoryReference(fmt.Sprintf("%s/%s", registryName, repoName))
 		if err != nil {
-			logger.Error("Error parsing repository name, skipping")
-			logrus.Error(err)
+			logger.Error("Error parsing repository name, skipping", "err", err)
 			continue
 		}
 
@@ -427,8 +408,7 @@ func filterSourceReferences(sys *types.SystemContext, registryName string, colle
 		logger.Info("Querying registry for image tags")
 		sourceReferences, err = imagesToCopyFromRepo(sys, repoRef)
 		if err != nil {
-			logger.Error("Error processing repo, skipping")
-			logrus.Error(err)
+			logger.Error("Error processing repo, skipping", "err", err)
 			continue
 		}
 
@@ -440,7 +420,7 @@ func filterSourceReferences(sys *types.SystemContext, registryName string, colle
 		}
 
 		if len(filteredSourceReferences) == 0 {
-			logger.Warnf("No refs to sync found")
+			logger.Warn("No refs to sync found")
 			continue
 		}
 
@@ -464,10 +444,10 @@ func tagRegexFilterCollection(collection map[string]string) (filterCollection, e
 			return nil, err
 		}
 
-		f := func(logger *logrus.Entry, sourceReference types.ImageReference) bool {
+		f := func(logger *slog.Logger, sourceReference types.ImageReference) bool {
 			tagged, isTagged := sourceReference.DockerReference().(reference.Tagged)
 			if !isTagged {
-				logger.Errorf("Internal error, reference %s does not have a tag, skipping", sourceReference.DockerReference())
+				logger.Error("Internal error, reference does not have a tag, skipping", "ref", sourceReference.DockerReference())
 				return false
 			}
 			return pattern.MatchString(tagged.Tag())
@@ -490,15 +470,15 @@ func semverFilterCollection(collection map[string]string) (filterCollection, err
 			return nil, err
 		}
 
-		f := func(logger *logrus.Entry, sourceReference types.ImageReference) bool {
+		f := func(logger *slog.Logger, sourceReference types.ImageReference) bool {
 			tagged, isTagged := sourceReference.DockerReference().(reference.Tagged)
 			if !isTagged {
-				logger.Errorf("Internal error, reference %s does not have a tag, skipping", sourceReference.DockerReference())
+				logger.Error("Internal error, reference does not have a tag, skipping", "ref", sourceReference.DockerReference())
 				return false
 			}
 			tagVersion, err := semver.NewVersion(tagged.Tag())
 			if err != nil {
-				logger.Tracef("Tag %q cannot be parsed as semver, skipping", tagged.Tag())
+				logger.Debug("Tag cannot be parsed as semver, skipping", "tag", tagged.Tag())
 				return false
 			}
 			return constraint.Check(tagVersion)
@@ -528,10 +508,7 @@ func imagesToCopy(source string, transport string, sourceCtx *types.SystemContex
 			return nil, fmt.Errorf("Cannot obtain a valid image reference for transport %q and reference %q: %w", docker.Transport.Name(), source, err)
 		}
 		imageTagged := !reference.IsNameOnly(named)
-		logrus.WithFields(logrus.Fields{
-			"imagename": source,
-			"tagged":    imageTagged,
-		}).Info("Tag presence check")
+		slog.Info("Tag presence check", "imagename", source, "tagged", imageTagged)
 		if imageTagged {
 			srcRef, err := docker.NewReference(named)
 			if err != nil {
@@ -662,7 +639,7 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 	errorsPresent := false
 	imagesNumber := 0
 	if opts.dryRun {
-		logrus.Warn("Running in dry-run mode")
+		slog.Warn("Running in dry-run mode")
 	}
 
 	var digestFile *os.File
@@ -705,14 +682,11 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 				return err
 			}
 
-			fromToFields := logrus.Fields{
-				"from": transports.ImageName(ref),
-				"to":   transports.ImageName(destRef),
-			}
+			fromToFields := slog.With("from", transports.ImageName(ref), "to", transports.ImageName(destRef))
 			if opts.dryRun {
-				logrus.WithFields(fromToFields).Infof("Would have copied image ref %d/%d", counter+1, len(srcRepo.ImageRefs))
+				fromToFields.Info(fmt.Sprintf("Would have copied image ref %d/%d", counter+1, len(srcRepo.ImageRefs)))
 			} else {
-				logrus.WithFields(fromToFields).Infof("Copying image ref %d/%d", counter+1, len(srcRepo.ImageRefs))
+				fromToFields.Info(fmt.Sprintf("Copying image ref %d/%d", counter+1, len(srcRepo.ImageRefs)))
 				if err = retry.IfNecessary(ctx, func() error {
 					manifestBytes, err = copy.Image(ctx, policyContext, destRef, ref, options)
 					return err
@@ -723,7 +697,7 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 					// log the error, keep a note that there was a failure and move on to the next
 					// image ref
 					errorsPresent = true
-					logrus.WithError(err).Errorf("Error copying ref %q", transports.ImageName(ref))
+					slog.Error("Error copying", "ref", transports.ImageName(ref), "err", err)
 					continue
 				}
 				// Ensure that we log the manifest digest to a file only if the copy operation was successful
@@ -744,9 +718,9 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 	}
 
 	if opts.dryRun {
-		logrus.Infof("Would have synced %d images from %d sources", imagesNumber, len(srcRepoList))
+		slog.Info(fmt.Sprintf("Would have synced %d images from %d sources", imagesNumber, len(srcRepoList)))
 	} else {
-		logrus.Infof("Synced %d images from %d sources", imagesNumber, len(srcRepoList))
+		slog.Info(fmt.Sprintf("Synced %d images from %d sources", imagesNumber, len(srcRepoList)))
 	}
 	if !errorsPresent {
 		return nil

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -12,7 +13,6 @@ import (
 	dockerdistributionerrcode "github.com/docker/distribution/registry/api/errcode"
 	dockerdistributionapi "github.com/docker/distribution/registry/api/v2"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	commonFlag "go.podman.io/common/pkg/flag"
@@ -90,7 +90,7 @@ type deprecatedTLSVerifyOption struct {
 // ends up being used.
 func (opts *deprecatedTLSVerifyOption) warnIfUsed(alternatives []string) {
 	if opts.tlsVerify.Present() {
-		logrus.Warnf("'--tls-verify' is deprecated, instead use: %s", strings.Join(alternatives, ", "))
+		slog.Warn(fmt.Sprintf("'--tls-verify' is deprecated, instead use: %s", strings.Join(alternatives, ", ")))
 	}
 }
 
@@ -320,10 +320,10 @@ func (opts *imageDestOptions) newSystemContext() (*types.SystemContext, error) {
 func (opts *imageDestOptions) warnAboutIneffectiveOptions(destTransport types.ImageTransport) {
 	if destTransport.Name() != directory.Transport.Name() {
 		if opts.dirForceCompression {
-			logrus.Warnf("--%s can only be used if the destination transport is 'dir'", opts.imageDestFlagPrefix+"compress")
+			slog.Warn(fmt.Sprintf("--%s can only be used if the destination transport is 'dir'", opts.imageDestFlagPrefix+"compress"))
 		}
 		if opts.dirForceDecompression {
-			logrus.Warnf("--%s can only be used if the destination transport is 'dir'", opts.imageDestFlagPrefix+"decompress")
+			slog.Warn(fmt.Sprintf("--%s can only be used if the destination transport is 'dir'", opts.imageDestFlagPrefix+"decompress"))
 		}
 	}
 }

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -872,7 +872,7 @@ func (s *copySuite) TestCopySignatures() {
 
 	// Verify that signed identity is verified.
 	assertSkopeoSucceeds(t, "", "--tls-verify=false", "copy", "atomic:localhost:5006/myns/official:official", "atomic:localhost:5006/myns/naming:test1")
-	assertSkopeoFails(t, `.*Source image rejected: Signature for identity \\"localhost:5006/myns/official:official\\" is not accepted.*`,
+	assertSkopeoFails(t, `.*Source image rejected: Signature for identity "localhost:5006/myns/official:official" is not accepted.*`,
 		"--tls-verify=false", "--policy", policy, "copy", "atomic:localhost:5006/myns/naming:test1", dirDest)
 	// signedIdentity works
 	assertSkopeoSucceeds(t, "", "--tls-verify=false", "copy", "atomic:localhost:5006/myns/official:official", "atomic:localhost:5006/myns/naming:naming")
@@ -933,7 +933,7 @@ func (s *copySuite) TestCopyDirSignatures() {
 	// Verify that the signed identity is verified.
 	assertSkopeoSucceeds(t, "", "--tls-verify=false", "--policy", policy, "copy", "--sign-by", "official@example.com", topDirDest+"/dir1", "atomic:localhost:5000/myns/personal:dirstaging2")
 	assertSkopeoSucceeds(t, "", "--tls-verify=false", "copy", "atomic:localhost:5000/myns/personal:dirstaging2", topDirDest+"/restricted/badidentity")
-	assertSkopeoFails(t, `.*Source image rejected: .*Signature for identity \\"localhost:5000/myns/personal:dirstaging2\\" is not accepted.*`,
+	assertSkopeoFails(t, `.*Source image rejected: .*Signature for identity "localhost:5000/myns/personal:dirstaging2" is not accepted.*`,
 		"--policy", policy, "copy", topDirDest+"/restricted/badidentity", topDirDest+"/dest")
 }
 
@@ -1191,7 +1191,7 @@ func (s *copySuite) TestCopyVerifyingMirroredSignatures() {
 	// … but verify that while it is accessible using the primary location redirecting to the mirror, …
 	assertSkopeoSucceeds(t, "" /* no --policy */, "--registries-conf", "fixtures/registries.conf", "copy", "--src-tls-verify=false", regPrefix+"primary:mirror-signed", dirDest)
 	// … verify it is NOT accessible when requiring a signature.
-	assertSkopeoFails(t, `.*Source image rejected: None of the signatures were accepted, reasons: Signature for identity \\"localhost:5006/myns/mirroring-primary:direct\\" is not accepted; Signature for identity \\"localhost:5006/myns/mirroring-mirror:mirror-signed\\" is not accepted.*`,
+	assertSkopeoFails(t, `.*Source image rejected: None of the signatures were accepted, reasons: Signature for identity "localhost:5006/myns/mirroring-primary:direct" is not accepted; Signature for identity "localhost:5006/myns/mirroring-mirror:mirror-signed" is not accepted.*`,
 		"--policy", policy, "--registries.d", registriesDir, "--registries-conf", "fixtures/registries.conf", "copy", "--src-tls-verify=false", regPrefix+"primary:mirror-signed", dirDest)
 
 	// Fail if we specify an unqualified identity
@@ -1205,14 +1205,14 @@ func (s *copySuite) TestCopyVerifyingMirroredSignatures() {
 	// … but verify that while it is accessible using the mirror location
 	assertSkopeoSucceeds(t, "" /* no --policy */, "--registries-conf", "fixtures/registries.conf", "copy", "--src-tls-verify=false", regPrefix+"mirror:primary-signed", dirDest)
 	// … verify it is NOT accessible when requiring a signature.
-	assertSkopeoFails(t, `.*Source image rejected: None of the signatures were accepted, reasons: Signature for identity \\"localhost:5006/myns/mirroring-primary:direct\\" is not accepted; Signature for identity \\"localhost:5006/myns/mirroring-mirror:mirror-signed\\" is not accepted; Signature for identity \\"localhost:5006/myns/mirroring-primary:primary-signed\\" is not accepted.*`,
+	assertSkopeoFails(t, `.*Source image rejected: None of the signatures were accepted, reasons: Signature for identity "localhost:5006/myns/mirroring-primary:direct" is not accepted; Signature for identity "localhost:5006/myns/mirroring-mirror:mirror-signed" is not accepted; Signature for identity "localhost:5006/myns/mirroring-primary:primary-signed" is not accepted.*`,
 		"--policy", policy, "--registries.d", registriesDir, "--registries-conf", "fixtures/registries.conf", "copy", "--src-tls-verify=false", regPrefix+"mirror:primary-signed", dirDest)
 
 	assertSkopeoSucceeds(t, "", "--registries.d", registriesDir, "--registries-conf", "fixtures/registries.conf", "copy", "--src-tls-verify=false", "--dest-tls-verify=false", regPrefix+"primary:unsigned", regPrefix+"remap:remapped")
 	// Verify that while a remapIdentity image is accessible using the remapped (mirror) location
 	assertSkopeoSucceeds(t, "" /* no --policy */, "--registries.d", registriesDir, "--registries-conf", "fixtures/registries.conf", "copy", "--src-tls-verify=false", regPrefix+"remap:remapped", dirDest)
 	// … it is NOT accessible when requiring a signature …
-	assertSkopeoFails(t, `.*Source image rejected: None of the signatures were accepted, reasons: Signature for identity \\"localhost:5006/myns/mirroring-primary:direct\\" is not accepted; Signature for identity \\"localhost:5006/myns/mirroring-mirror:mirror-signed\\" is not accepted; Signature for identity \\"localhost:5006/myns/mirroring-primary:primary-signed\\" is not accepted.*`, "--policy", policy, "--registries.d", registriesDir, "--registries-conf", "fixtures/registries.conf", "copy", "--src-tls-verify=false", regPrefix+"remap:remapped", dirDest)
+	assertSkopeoFails(t, `.*Source image rejected: None of the signatures were accepted, reasons: Signature for identity "localhost:5006/myns/mirroring-primary:direct" is not accepted; Signature for identity "localhost:5006/myns/mirroring-mirror:mirror-signed" is not accepted; Signature for identity "localhost:5006/myns/mirroring-primary:primary-signed" is not accepted.*`, "--policy", policy, "--registries.d", registriesDir, "--registries-conf", "fixtures/registries.conf", "copy", "--src-tls-verify=false", regPrefix+"remap:remapped", dirDest)
 	// … until signed.
 	assertSkopeoSucceeds(t, "", "--registries.d", registriesDir, "copy", "--src-tls-verify=false", "--dest-tls-verify=false", "--sign-by=personal@example.com", "--sign-identity=localhost:5006/myns/mirroring-primary:remapped", regPrefix+"remap:remapped", regPrefix+"remap:remapped")
 	assertSkopeoSucceeds(t, "", "--policy", policy, "--registries.d", registriesDir, "--registries-conf", "fixtures/registries.conf", "copy", "--src-tls-verify=false", regPrefix+"remap:remapped", dirDest)

--- a/systemtest/010-inspect.bats
+++ b/systemtest/010-inspect.bats
@@ -103,7 +103,7 @@ END_EXPECT
 
     # By default, 'inspect' tries to match our host os+arch. This should fail.
     run_skopeo 1 inspect $img
-    expect_output --substring "parsing manifest for image: choosing image instance: no image found in manifest list for architecture \\\\\"$arch\\\\\", variant " \
+    expect_output --substring "parsing manifest for image: choosing image instance: no image found in manifest list for architecture \"$arch\", variant " \
                   "skopeo inspect, without --raw, fails"
 
     # With --raw, we can inspect

--- a/systemtest/050-signing.bats
+++ b/systemtest/050-signing.bats
@@ -157,7 +157,7 @@ END_PUSH
     done <<END_TESTS
 /myns/alice:signed
 /myns/bob:signedbyalice    (Invalid GPG signature|Missing key)
-/myns/alice:unsigned       Signature for identity \\\\\\\\"localhost:5000/myns/alice:signed\\\\\\\\" is not accepted
+/myns/alice:unsigned       Signature for identity "localhost:5000/myns/alice:signed" is not accepted
 /myns/carol:latest         Running image docker://localhost:5000/myns/carol:latest is rejected by policy.
 /open/forall:latest
 END_TESTS

--- a/systemtest/080-sync.bats
+++ b/systemtest/080-sync.bats
@@ -15,7 +15,7 @@ function setup() {
 
     run_skopeo sync --dry-run --src docker --dest dir --scoped $remote_image $dir
     expect_output --substring "Would have copied image"
-    expect_output --substring "from=\"docker://${remote_image}\" to=\"dir:${dir}/${remote_image}\""
+    expect_output --substring "from=docker://${remote_image} to=dir:${dir}/${remote_image}"
     expect_output --substring "Would have synced 1 images from 1 sources"
 }
 

--- a/vendor/github.com/sirupsen/logrus/hooks/slog/handler.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/slog/handler.go
@@ -1,0 +1,201 @@
+package slog
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"runtime"
+	"slices"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// HandlerOptions are options for a [Handler].
+// A zero HandlerOptions consists entirely of default values.
+type HandlerOptions struct {
+	// AddSource causes the handler to include the source code position
+	// of the log statement in the Logrus entry.
+	AddSource bool
+
+	// LevelMapper maps slog levels to Logrus levels. If nil, the default
+	// mapping is used. Set it to customize level mapping, for example to map
+	// custom slog levels to specific Logrus levels.
+	LevelMapper func(slog.Level) logrus.Level
+}
+
+// Handler is a [slog.Handler] that writes records to a [logrus.Logger].
+//
+// It is intended for bridging libraries or application code that log via slog
+// into an existing Logrus logger, for example during a gradual migration.
+//
+// By default, slog levels are mapped using [SlogLevel].
+// Set [HandlerOptions.LevelMapper] to customize the mapping.
+//
+// Mapping to [logrus.FatalLevel] or [logrus.PanicLevel] preserves the level
+// only; handling a record does not exit or panic.
+type Handler struct {
+	logger *logrus.Logger
+	opts   HandlerOptions
+
+	// fields holds attributes from prior WithAttrs calls, already resolved
+	// under the group prefix that applied when they were added.
+	fields logrus.Fields
+
+	// groups is the current group name stack for attributes added later.
+	groups []string
+}
+
+var _ slog.Handler = (*Handler)(nil)
+
+// NewHandler creates a [slog.Handler] that writes to the provided
+// [logrus.Logger].
+//
+// The provided logger must not be nil. NewHandler panics if logger is nil.
+// If opts is nil, the default options are used.
+func NewHandler(logger *logrus.Logger, opts *HandlerOptions) *Handler {
+	if logger == nil {
+		panic("cannot create handler from nil logger")
+	}
+	if opts == nil {
+		opts = &HandlerOptions{}
+	}
+	return &Handler{
+		logger: logger,
+		opts:   *opts,
+	}
+}
+
+// toLogrusLevel maps a slog level using LevelMapper or the default mapping.
+func (h *Handler) toLogrusLevel(level slog.Level) logrus.Level {
+	if h.opts.LevelMapper != nil {
+		return h.opts.LevelMapper(level)
+	}
+	return SlogLevel(level).Level()
+}
+
+// Enabled reports whether the handler handles records at the given level.
+// It maps the slog level to a logrus level and consults the underlying logger.
+func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
+	return h.logger.IsLevelEnabled(h.toLogrusLevel(level))
+}
+
+// Handle converts the slog record into a logrus entry and logs it.
+// Record time, context, message, and attributes (including those from
+// [Handler.WithAttrs]/[Handler.WithGroup]) are preserved. Attributes are
+// attached as logrus fields; group names are joined with "." as a key prefix
+// (similar to [slog.TextHandler]).
+func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
+	// Stop recursive forwarding before it can cycle back through this logger.
+	if hasLogrusLogger(ctx, h.logger) {
+		return nil
+	}
+	level := h.toLogrusLevel(record.Level)
+	if !h.logger.IsLevelEnabled(level) {
+		return nil
+	}
+
+	entry := &logrus.Entry{
+		Logger:  h.logger,
+		Data:    h.fields,
+		Time:    record.Time,
+		Context: ctx,
+	}
+
+	if h.opts.AddSource && record.PC != 0 {
+		// Preserve the caller selected by slog instead of rediscovering it
+		// through Logrus's caller stack filtering.
+		//
+		// Record.PC is a return PC; resolve it with CallersFrames.
+		frame, _ := runtime.CallersFrames([]uintptr{record.PC}).Next()
+		entry.Caller = &frame
+	}
+
+	if n := record.NumAttrs(); n > 0 {
+		// Clone before mutating the handler's fields.
+		entry.Data = maps.Clone(h.fields)
+		if entry.Data == nil {
+			entry.Data = make(logrus.Fields, n)
+		}
+		record.Attrs(func(a slog.Attr) bool {
+			appendAttr(entry.Data, h.groups, a)
+			return true
+		})
+	}
+
+	entry.Log(level, record.Message)
+	return nil
+}
+
+// WithAttrs returns a new Handler whose attributes consist of h's attributes
+// followed by attrs.
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	h2 := h.clone()
+	h2.fields = maps.Clone(h.fields)
+	if h2.fields == nil {
+		h2.fields = make(logrus.Fields, len(attrs))
+	}
+	for _, a := range attrs {
+		appendAttr(h2.fields, h.groups, a)
+	}
+	return h2
+}
+
+// WithGroup returns a new Handler with a group appended to the receiver's
+// existing groups. All attributes added to the returned handler (via WithAttrs
+// or Handle) are nested under the combined group names.
+// If name is empty, WithGroup returns h unchanged.
+func (h *Handler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	h2 := h.clone()
+	h2.groups = append(slices.Clip(h.groups), name)
+	return h2
+}
+
+// clone returns a shallow copy of h. Callers must clone fields or groups
+// before modifying them.
+func (h *Handler) clone() *Handler {
+	return &Handler{
+		logger: h.logger,
+		opts:   h.opts,
+		fields: h.fields,
+		groups: h.groups,
+	}
+}
+
+// appendAttr adds attr to fields, resolving it and applying group prefixes.
+// Group attributes are flattened with "."-separated keys.
+func appendAttr(fields logrus.Fields, groups []string, attr slog.Attr) {
+	attr.Value = attr.Value.Resolve()
+	if attr.Equal(slog.Attr{}) {
+		return
+	}
+	if attr.Value.Kind() == slog.KindGroup {
+		gs := attr.Value.Group()
+		if len(gs) == 0 {
+			return
+		}
+		g := groups
+		if attr.Key != "" {
+			g = append(slices.Clip(groups), attr.Key)
+		}
+		for _, a := range gs {
+			appendAttr(fields, g, a)
+		}
+		return
+	}
+
+	key := attr.Key
+	if len(groups) > 0 {
+		key = strings.Join(groups, ".")
+		if attr.Key != "" {
+			key += "." + attr.Key
+		}
+	}
+	fields[key] = attr.Value.Any()
+}

--- a/vendor/github.com/sirupsen/logrus/hooks/slog/level.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/slog/level.go
@@ -1,0 +1,119 @@
+package slog
+
+import (
+	"log/slog"
+
+	"github.com/sirupsen/logrus"
+)
+
+// slog levels corresponding to Logrus levels.
+const (
+	slogLevelTrace = slog.LevelDebug - 4
+	slogLevelDebug = slog.LevelDebug
+	slogLevelInfo  = slog.LevelInfo
+	slogLevelWarn  = slog.LevelWarn
+	slogLevelError = slog.LevelError
+	slogLevelFatal = slog.LevelError + 2
+	slogLevelPanic = slog.LevelError + 4
+)
+
+// A Leveler provides a [logrus.Level] value.
+//
+// It is the Logrus counterpart of [slog.Leveler].
+//
+// As [SlogLevel] itself implements Leveler, clients typically supply
+// a SlogLevel value wherever a Leveler is needed.
+// Clients who need to vary the level dynamically can provide a more complex
+// Leveler implementation.
+type Leveler interface {
+	Level() logrus.Level
+}
+
+// Level adapts a [logrus.Level] to a [slog.Leveler] using the default
+// Logrus-to-slog level mapping:
+//
+//   - [logrus.TraceLevel] -> [slog.LevelDebug] - 4
+//   - [logrus.DebugLevel] -> [slog.LevelDebug]
+//   - [logrus.InfoLevel] -> [slog.LevelInfo]
+//   - [logrus.WarnLevel] -> [slog.LevelWarn]
+//   - [logrus.ErrorLevel] -> [slog.LevelError]
+//   - [logrus.FatalLevel] -> [slog.LevelError] + 2
+//   - [logrus.PanicLevel] -> [slog.LevelError] + 4
+//
+// Unknown Logrus levels map to [slog.LevelError].
+type Level logrus.Level
+
+// Level returns l mapped to the corresponding slog level.
+func (l Level) Level() slog.Level {
+	return toSlogLevel(logrus.Level(l))
+}
+
+var _ slog.Leveler = Level(0)
+
+// SlogLevel adapts a [slog.Level] to a [Leveler] using the default
+// slog-to-Logrus level mapping:
+//
+//   - [slog.LevelDebug] - 4 -> [logrus.TraceLevel]
+//   - [slog.LevelDebug] -> [logrus.DebugLevel]
+//   - [slog.LevelInfo] -> [logrus.InfoLevel]
+//   - [slog.LevelWarn] -> [logrus.WarnLevel]
+//   - [slog.LevelError] -> [logrus.ErrorLevel]
+//   - [slog.LevelError] + 2 -> [logrus.FatalLevel]
+//   - [slog.LevelError] + 4 -> [logrus.PanicLevel]
+//
+// Levels between these boundaries map to the next lower Logrus severity.
+// Levels below [slog.LevelDebug] map to [logrus.TraceLevel], and levels at or
+// above the Panic boundary map to [logrus.PanicLevel].
+type SlogLevel slog.Level
+
+// Level returns l mapped to the corresponding Logrus level.
+func (l SlogLevel) Level() logrus.Level {
+	return toLogrusLevel(slog.Level(l))
+}
+
+var _ Leveler = SlogLevel(0)
+
+// toLogrusLevel maps a slog level using the default mapping.
+func toLogrusLevel(level slog.Level) logrus.Level {
+	switch {
+	case level >= slogLevelPanic:
+		return logrus.PanicLevel
+	case level >= slogLevelFatal:
+		return logrus.FatalLevel
+	case level >= slogLevelError:
+		return logrus.ErrorLevel
+	case level >= slogLevelWarn:
+		return logrus.WarnLevel
+	case level >= slogLevelInfo:
+		return logrus.InfoLevel
+	case level >= slogLevelDebug:
+		return logrus.DebugLevel
+	case level >= slogLevelTrace:
+		return logrus.TraceLevel
+	default:
+		return logrus.TraceLevel
+	}
+}
+
+// toSlogLevel maps a Logrus level using the default mapping.
+func toSlogLevel(level logrus.Level) slog.Level {
+	switch level {
+	case logrus.PanicLevel:
+		return slogLevelPanic
+	case logrus.FatalLevel:
+		return slogLevelFatal
+	case logrus.ErrorLevel:
+		return slogLevelError
+	case logrus.WarnLevel:
+		return slogLevelWarn
+	case logrus.InfoLevel:
+		return slogLevelInfo
+	case logrus.DebugLevel:
+		return slogLevelDebug
+	case logrus.TraceLevel:
+		return slogLevelTrace
+	default:
+		// Treat all unknown levels as errors
+		return slogLevelError
+	}
+}

--- a/vendor/github.com/sirupsen/logrus/hooks/slog/slog.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/slog/slog.go
@@ -1,0 +1,126 @@
+// Package slog provides adapters between Logrus and log/slog.
+//
+// [Handler] forwards slog records to a Logrus logger, while [Hook] forwards
+// Logrus entries to a slog logger. They can be used independently to support
+// incremental migration between the two logging APIs.
+package slog
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+
+	"github.com/sirupsen/logrus"
+)
+
+// logrusLoggerContextKey is the context key used to track Logrus loggers a
+// record has already traversed while being forwarded through slog adapters.
+type logrusLoggerContextKey struct{}
+
+// withLogrusLogger returns a context that records logger as having already
+// handled the current log record.
+func withLogrusLogger(ctx context.Context, logger *logrus.Logger) context.Context {
+	seen, _ := ctx.Value(logrusLoggerContextKey{}).(map[*logrus.Logger]struct{})
+	seen = maps.Clone(seen)
+	if seen == nil {
+		seen = make(map[*logrus.Logger]struct{}, 1)
+	}
+	seen[logger] = struct{}{}
+	return context.WithValue(ctx, logrusLoggerContextKey{}, seen)
+}
+
+// hasLogrusLogger reports whether logger has already handled the current log
+// record while it was forwarded through slog adapters.
+func hasLogrusLogger(ctx context.Context, logger *logrus.Logger) bool {
+	seen, _ := ctx.Value(logrusLoggerContextKey{}).(map[*logrus.Logger]struct{})
+	_, ok := seen[logger]
+	return ok
+}
+
+// HookOptions are options for a [Hook].
+// A zero HookOptions consists entirely of default values.
+type HookOptions struct {
+	// LevelMapper maps Logrus levels to slog levels. If nil, the default
+	// mapping is used. Set it to customize level mapping, for example to map
+	// custom Logrus levels to specific slog levels.
+	LevelMapper func(logrus.Level) slog.Level
+}
+
+// Hook sends Logrus entries to slog.
+//
+// It is intended for bridging libraries or application code that log via
+// Logrus into an existing slog logger, for example during a gradual migration.
+//
+// By default, Logrus levels are mapped using [Level]. Set
+// [HookOptions.LevelMapper] to customize the mapping.
+type Hook struct {
+	logger *slog.Logger
+	opts   HookOptions
+}
+
+var _ logrus.Hook = (*Hook)(nil)
+
+// NewHook creates a [logrus.Hook] that sends logs to the provided [slog.Logger].
+//
+// This hook is intended to be used during transition from Logrus to slog,
+// or as a shim between different parts of your application or different
+// libraries that depend on different loggers.
+//
+// The provided logger must not be nil. NewHook panics if logger is nil.
+// If opts is nil, the default options are used.
+func NewHook(logger *slog.Logger, opts *HookOptions) *Hook {
+	if logger == nil {
+		panic("cannot create hook from nil logger")
+	}
+	if opts == nil {
+		opts = &HookOptions{}
+	}
+	return &Hook{
+		logger: logger,
+		opts:   *opts,
+	}
+}
+
+// toSlogLevel maps a Logrus level using LevelMapper or the default mapping.
+func (h *Hook) toSlogLevel(level logrus.Level) slog.Level {
+	if h.opts.LevelMapper != nil {
+		return h.opts.LevelMapper(level)
+	}
+	return Level(level).Level()
+}
+
+// Levels always returns all levels, since slog allows controlling level
+// enabling based on context.
+func (h *Hook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire forwards the provided logrus Entry to the underlying slog.Logger's
+// Handler, mapping it to a slog.Record. Time and caller information are
+// preserved when available, and Entry.Data is converted to attributes.
+// If Entry.Context is nil, context.Background() is used.
+func (h *Hook) Fire(entry *logrus.Entry) error {
+	ctx := entry.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// Track this logger to guard against recursive forwarding.
+	ctx = withLogrusLogger(ctx, entry.Logger)
+
+	level := h.toSlogLevel(entry.Level)
+	handler := h.logger.Handler()
+	if !handler.Enabled(ctx, level) {
+		return nil
+	}
+	attrs := make([]slog.Attr, 0, len(entry.Data))
+	for k, v := range entry.Data {
+		attrs = append(attrs, slog.Any(k, v))
+	}
+	var pc uintptr
+	if entry.Caller != nil {
+		pc = entry.Caller.PC
+	}
+	r := slog.NewRecord(entry.Time, level, entry.Message, pc)
+	r.AddAttrs(attrs...)
+	return handler.Handle(ctx, r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -312,6 +312,7 @@ github.com/sigstore/sigstore/pkg/signature/payload
 # github.com/sirupsen/logrus v1.10.2
 ## explicit; go 1.23
 github.com/sirupsen/logrus
+github.com/sirupsen/logrus/hooks/slog
 # github.com/smallstep/pkcs7 v0.2.1
 ## explicit; go 1.14
 github.com/smallstep/pkcs7


### PR DESCRIPTION
RFC @podman-container-tools/core-maintainers , for doing something like this project-wide.

Direct `logrus.*` calls to `log/slog.Default()`. logrus 1.10.0 includes that as a native feature, I think that’s the best hint to migrate to the standard logging mechanisms we are ever going to get.

I’d suggest adding the logging redirect infrastructure to `main` of the various projects, _with no plan to immediately migrate_ — lot of churn we just don’t need; but for new code, we would ask for `log/slog` to be used.

This PR does migrate the few uses in Skopeo, basically to demonstrate what that looks like (both the `Sprintf`s at the very top level, and the more useful usage within `sync.go`).

---

This changes formatting, from 
```
FATA[0001] Error ...
```
(with the `FATA` red, and the `[0001]` part, very unintuitively, a timestamp in seconds) when interactive, and from
```
time="2026-08-14T00:24:59+02:00" level=fatal msg="Error..."
```
when non-interactive, to
```
ERROR Error ...
```    
    
I think that is good enough, probably a bit of an improvement; we can tweak the formatting later if necessary.

---

The more important aspect is that `log/slog` does not provide `Printf`-like helpers (although a manual `Sprintf` is always an option), strongly directing callers towards a key-value format. Given that _most_ logs are for debugging or unexpected situations, that seems acceptable (especially if it allows sharing some fields,
```go
logger := slog.With("fields", "relevant", "to-the-whole", "function")
…
logger.Error("step A failed", "err", err)
…
logger.Error("step C failed", "err", err)
```
can be more consistent and less repetitive).