### PR TITLE
Silence golangci-lint on non-Sequoia runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ SEQUOIA_SONAME_DIR =
 # N/B: This value is managed by Renovate, manual changes are
 # possible, as long as they don't disturb the formatting
 # (i.e. DO NOT ADD A 'v' prefix!)
-GOLANGCI_LINT_VERSION := 2.12.2
+GOLANGCI_LINT_VERSION := 2.13.0
 
 ifeq ($(GOBIN),)
 GOBIN := $(GOPATH)/bin

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -449,8 +449,8 @@ func (opts *sharedCopyOptions) copyOptions(stdout io.Writer) (*copy.Options, fun
 		if passphraseSet {
 			sqOpts = append(sqOpts, simplesequoia.WithPassphrase(passphrase))
 		}
-		signer, err := simplesequoia.NewSigner(sqOpts...)
-		if err != nil {
+		signer, err := simplesequoia.NewSigner(sqOpts...) //nolint:staticcheck // SA4023: without the containers_image_sequoia build tag, this always fails.
+		if err != nil {                                   //nolint:staticcheck // SA4023 … and staticcheck reports both the comparison and the "related" call.
 			return nil, nil, fmt.Errorf("Error using --sign-by-sq-fingerprint: %w", err)
 		}
 		signers = append(signers, signer)


### PR DESCRIPTION
On runs without the `containers_image_sequoia` tag, it detects that this comparison always fails. (Lint runs with the tag do succeed.)

The SA4023 explanation focuses on converting a typed pointer to an interface, but an experiment shows that this also triggers on a minimal `(errors.New("...") == nil)`.

@podman-container-tools/skopeo-maintainers PTAL. This is a prerequisite for #2965.