### PR TITLE
Change how we report top-level errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,14 +5,10 @@ formatters:
     - gofumpt
 
 linters:
-  settings:
-    staticcheck:
-      checks:
-        # Compared to golangci-lint v2.0.2 defaults, we don’t exclude
-        # ST1003, ST1016, ST1020, ST1021, ST1022 as we don't hit those.
-        - all
-        - -ST1000 # Incorrect or missing package comment.
-        - -ST1005 # Incorrectly formatted error string.
   exclusions:
     presets:
       - std-error-handling
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -127,7 +127,7 @@ func parseMultiArch(multiArch string) (copy.ImageListSelection, []copy.InstanceP
 
 func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 	if len(args) != 2 {
-		return errorShouldDisplayUsage{errors.New("Exactly two arguments expected")}
+		return errorShouldDisplayUsage{errors.New("exactly two arguments expected")}
 	}
 	opts.deprecatedTLSVerify.warnIfUsed([]string{"--src-tls-verify", "--dest-tls-verify"})
 	imageNames := args
@@ -138,7 +138,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 
 	policyContext, err := opts.global.getPolicyContext()
 	if err != nil {
-		return fmt.Errorf("Error loading trust policy: %v", err)
+		return fmt.Errorf("loading trust policy: %w", err)
 	}
 	defer func() {
 		if err := policyContext.Destroy(); err != nil {
@@ -148,11 +148,11 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 
 	srcRef, err := alltransports.ParseImageName(imageNames[0])
 	if err != nil {
-		return fmt.Errorf("Invalid source name %s: %v", imageNames[0], err)
+		return fmt.Errorf("invalid source name %s: %w", imageNames[0], err)
 	}
 	destRef, err := alltransports.ParseImageName(imageNames[1])
 	if err != nil {
-		return fmt.Errorf("Invalid destination name %s: %v", imageNames[1], err)
+		return fmt.Errorf("invalid destination name %s: %w", imageNames[1], err)
 	}
 
 	sourceCtx, err := opts.srcImage.newSystemContext()
@@ -167,7 +167,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 	for _, image := range opts.additionalTags {
 		ref, err := reference.ParseNormalizedNamed(image)
 		if err != nil {
-			return fmt.Errorf("error parsing additional-tag '%s': %v", image, err)
+			return fmt.Errorf("parsing additional-tag '%s': %w", image, err)
 		}
 		namedTagged, isNamedTagged := ref.(reference.NamedTagged)
 		if !isNamedTagged {
@@ -186,7 +186,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 	imageListSelection := copy.CopySystemImage
 	var instancePlatforms []copy.InstancePlatformFilter
 	if opts.multiArch.Present() && opts.all {
-		return fmt.Errorf("Cannot use --all and --multi-arch flags together")
+		return fmt.Errorf("cannot use --all and --multi-arch flags together")
 	}
 	if opts.multiArch.Present() {
 		imageListSelection, instancePlatforms, err = parseMultiArch(opts.multiArch.Value())
@@ -216,7 +216,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 		encryptionKeys := opts.encryptionKeys
 		ecc, err := enchelpers.CreateCryptoConfig(encryptionKeys, []string{})
 		if err != nil {
-			return fmt.Errorf("Invalid encryption keys: %v", err)
+			return fmt.Errorf("invalid encryption keys: %w", err)
 		}
 		cc := encconfig.CombineCryptoConfigs([]encconfig.CryptoConfig{ecc})
 		encConfig = cc.EncryptConfig
@@ -227,7 +227,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 		decryptionKeys := opts.decryptionKeys
 		dcc, err := enchelpers.CreateCryptoConfig([]string{}, decryptionKeys)
 		if err != nil {
-			return fmt.Errorf("Invalid decryption keys: %v", err)
+			return fmt.Errorf("invalid decryption keys: %w", err)
 		}
 		cc := encconfig.CombineCryptoConfigs([]encconfig.CryptoConfig{dcc})
 		decConfig = cc.DecryptConfig
@@ -237,7 +237,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 	if opts.signIdentity != "" {
 		signIdentity, err = reference.ParseNamed(opts.signIdentity)
 		if err != nil {
-			return fmt.Errorf("Could not parse --sign-identity: %v", err)
+			return fmt.Errorf("parsing --sign-identity: %w", err)
 		}
 	}
 
@@ -275,7 +275,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 				return err
 			}
 			if err = os.WriteFile(opts.digestFile, []byte(manifestDigest.String()), 0o644); err != nil {
-				return fmt.Errorf("Failed to write digest to file %q: %w", opts.digestFile, err)
+				return fmt.Errorf("writing digest to file %q: %w", opts.digestFile, err)
 			}
 		}
 		return nil

--- a/cmd/skopeo/copy_test.go
+++ b/cmd/skopeo/copy_test.go
@@ -16,7 +16,7 @@ func TestCopy(t *testing.T) {
 		{"a1", "a2", "a3"},
 	} {
 		out, err := runSkopeo(append([]string{"--insecure-policy", "copy"}, args...)...)
-		assertTestFailed(t, out, err, "Exactly two arguments expected")
+		assertTestFailed(t, out, err, "exactly two arguments expected")
 	}
 
 	// FIXME: Much more test coverage

--- a/cmd/skopeo/delete.go
+++ b/cmd/skopeo/delete.go
@@ -49,7 +49,7 @@ See skopeo(1) section "IMAGE NAMES" for the expected format
 
 func (opts *deleteOptions) run(args []string, stdout io.Writer) error {
 	if len(args) != 1 {
-		return errors.New("Usage: delete imageReference")
+		return errorShouldDisplayUsage{errors.New("exactly one argument expected")}
 	}
 	imageName := args[0]
 

--- a/cmd/skopeo/delete.go
+++ b/cmd/skopeo/delete.go
@@ -59,7 +59,7 @@ func (opts *deleteOptions) run(args []string, stdout io.Writer) error {
 
 	ref, err := alltransports.ParseImageName(imageName)
 	if err != nil {
-		return fmt.Errorf("Invalid source name %s: %v", imageName, err)
+		return fmt.Errorf("invalid source name %s: %w", imageName, err)
 	}
 
 	sys, err := opts.image.newSystemContext()

--- a/cmd/skopeo/generate_sigstore_key.go
+++ b/cmd/skopeo/generate_sigstore_key.go
@@ -46,8 +46,11 @@ func ensurePathDoesNotExist(path string) error {
 }
 
 func (opts *generateSigstoreKeyOptions) run(args []string, stdout io.Writer) error {
-	if len(args) != 0 || opts.outputPrefix == "" {
-		return errors.New("Usage: generate-sigstore-key --output-prefix PREFIX")
+	if len(args) != 0 {
+		return errorShouldDisplayUsage{errors.New("no arguments expected")}
+	}
+	if opts.outputPrefix == "" {
+		return errorShouldDisplayUsage{errors.New("--output-prefix must be specified")}
 	}
 
 	pubKeyPath := opts.outputPrefix + ".pub"

--- a/cmd/skopeo/generate_sigstore_key.go
+++ b/cmd/skopeo/generate_sigstore_key.go
@@ -83,7 +83,7 @@ func (opts *generateSigstoreKeyOptions) run(args []string, stdout io.Writer) err
 		return fmt.Errorf("Error writing private key to %q: %w", privateKeyPath, err)
 	}
 	if err := os.WriteFile(pubKeyPath, keys.PublicKey, 0o644); err != nil {
-		return fmt.Errorf("Error writing private key to %q: %w", pubKeyPath, err)
+		return fmt.Errorf("Error writing public key to %q: %w", pubKeyPath, err)
 	}
 	fmt.Fprintf(stdout, "Key written to %q and %q\n", privateKeyPath, pubKeyPath)
 	return nil

--- a/cmd/skopeo/generate_sigstore_key.go
+++ b/cmd/skopeo/generate_sigstore_key.go
@@ -37,11 +37,11 @@ func generateSigstoreKeyCmd() *cobra.Command {
 func ensurePathDoesNotExist(path string) error {
 	switch _, err := os.Stat(path); {
 	case err == nil:
-		return fmt.Errorf("Refusing to overwrite existing %q", path)
+		return fmt.Errorf("refusing to overwrite existing %q", path)
 	case errors.Is(err, fs.ErrNotExist):
 		return nil
 	default:
-		return fmt.Errorf("Error checking existence of %q: %w", path, err)
+		return fmt.Errorf("checking existence of %q: %w", path, err)
 	}
 }
 
@@ -76,14 +76,14 @@ func (opts *generateSigstoreKeyOptions) run(args []string, stdout io.Writer) err
 
 	keys, err := sigstore.GenerateKeyPair([]byte(passphrase))
 	if err != nil {
-		return fmt.Errorf("Error generating key pair: %w", err)
+		return fmt.Errorf("generating key pair: %w", err)
 	}
 
 	if err := os.WriteFile(privateKeyPath, keys.PrivateKey, 0o600); err != nil {
-		return fmt.Errorf("Error writing private key to %q: %w", privateKeyPath, err)
+		return fmt.Errorf("writing private key to %q: %w", privateKeyPath, err)
 	}
 	if err := os.WriteFile(pubKeyPath, keys.PublicKey, 0o644); err != nil {
-		return fmt.Errorf("Error writing public key to %q: %w", pubKeyPath, err)
+		return fmt.Errorf("writing public key to %q: %w", pubKeyPath, err)
 	}
 	fmt.Fprintf(stdout, "Key written to %q and %q\n", privateKeyPath, pubKeyPath)
 	return nil

--- a/cmd/skopeo/generate_sigstore_key_test.go
+++ b/cmd/skopeo/generate_sigstore_key_test.go
@@ -11,13 +11,10 @@ import (
 
 func TestGenerateSigstoreKey(t *testing.T) {
 	// Invalid command-line arguments
-	for _, args := range [][]string{
-		{},
-		{"--output-prefix", "foo", "a1"},
-	} {
-		out, err := runSkopeo(append([]string{"generate-sigstore-key"}, args...)...)
-		assertTestFailed(t, out, err, "Usage")
-	}
+	out, err := runSkopeo("generate-sigstore-key")
+	assertTestFailed(t, out, err, "--output-prefix must be specified")
+	out, err = runSkopeo("generate-sigstore-key", "--output-prefix", "foo", "a1")
+	assertTestFailed(t, out, err, "no arguments expected")
 
 	// One of the destination files already exists
 	outputSuffixes := []string{".pub", ".private"}
@@ -49,7 +46,7 @@ func TestGenerateSigstoreKey(t *testing.T) {
 	}
 	destDir := t.TempDir()
 	// Error reading passphrase
-	out, err := runSkopeo("generate-sigstore-key",
+	out, err = runSkopeo("generate-sigstore-key",
 		"--output-prefix", filepath.Join(destDir, "prefix"),
 		"--passphrase-file", filepath.Join(destDir, "this-does-not-exist"),
 	)

--- a/cmd/skopeo/generate_sigstore_key_test.go
+++ b/cmd/skopeo/generate_sigstore_key_test.go
@@ -29,7 +29,7 @@ func TestGenerateSigstoreKey(t *testing.T) {
 		out, err := runSkopeo("generate-sigstore-key",
 			"--output-prefix", prefix, "--passphrase-file", "/dev/null",
 		)
-		assertTestFailed(t, out, err, "Refusing to overwrite")
+		assertTestFailed(t, out, err, "refusing to overwrite")
 	}
 
 	// One of the destinations is inaccessible (simulate by a symlink that tries to

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -80,7 +80,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 	defer cancel()
 
 	if len(args) != 1 {
-		return errors.New("Exactly one argument expected")
+		return errors.New("exactly one argument expected")
 	}
 	if opts.raw && opts.format != "" {
 		return errors.New("raw output does not support format option")
@@ -100,7 +100,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 		src, err = parseImageSource(ctx, opts.image, imageName)
 		return err
 	}, opts.retryOpts); err != nil {
-		return fmt.Errorf("Error parsing image name %q: %w", imageName, err)
+		return fmt.Errorf("parsing image name %q: %w", imageName, err)
 	}
 
 	defer func() {
@@ -114,13 +114,13 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 		rawManifest, _, err = unparsedInstance.Manifest(ctx)
 		return err
 	}, opts.retryOpts); err != nil {
-		return fmt.Errorf("Error retrieving manifest for image: %w", err)
+		return fmt.Errorf("retrieving manifest for image: %w", err)
 	}
 
 	if opts.raw && !opts.config {
 		_, err := stdout.Write(rawManifest)
 		if err != nil {
-			return fmt.Errorf("Error writing manifest to standard output: %w", err)
+			return fmt.Errorf("writing manifest to standard output: %w", err)
 		}
 
 		return nil
@@ -128,7 +128,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 
 	img, err := image.FromUnparsedImage(ctx, sys, unparsedInstance)
 	if err != nil {
-		return fmt.Errorf("Error parsing manifest for image: %w", err)
+		return fmt.Errorf("parsing manifest for image: %w", err)
 	}
 
 	if opts.config && opts.raw {
@@ -137,11 +137,11 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 			configBlob, err = img.ConfigBlob(ctx)
 			return err
 		}, opts.retryOpts); err != nil {
-			return fmt.Errorf("Error reading configuration blob: %w", err)
+			return fmt.Errorf("reading configuration blob: %w", err)
 		}
 		_, err = stdout.Write(configBlob)
 		if err != nil {
-			return fmt.Errorf("Error writing configuration blob to standard output: %w", err)
+			return fmt.Errorf("writing configuration blob to standard output: %w", err)
 		}
 		return nil
 	} else if opts.config {
@@ -150,10 +150,10 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 			config, err = img.OCIConfig(ctx)
 			return err
 		}, opts.retryOpts); err != nil {
-			return fmt.Errorf("Error reading OCI-formatted configuration data: %w", err)
+			return fmt.Errorf("reading OCI-formatted configuration data: %w", err)
 		}
 		if err := opts.writeOutput(stdout, config); err != nil {
-			return fmt.Errorf("Error writing OCI-formatted configuration data to standard output: %w", err)
+			return fmt.Errorf("writing OCI-formatted configuration data to standard output: %w", err)
 		}
 		return nil
 	}
@@ -181,7 +181,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 	}
 	outputData.Digest, err = manifestDigestFromManifest(rawManifest, img, opts.manifestDigest)
 	if err != nil {
-		return fmt.Errorf("Error computing manifest digest: %w", err)
+		return fmt.Errorf("computing manifest digest: %w", err)
 	}
 	if dockerRef := img.Reference().DockerReference(); dockerRef != nil {
 		outputData.Name = dockerRef.Name()
@@ -212,7 +212,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 				}
 			}
 			if fatalFailure {
-				return fmt.Errorf("Error determining repository tags: %w", err)
+				return fmt.Errorf("determining repository tags: %w", err)
 			}
 			slog.Warn("Registry disallows tag list retrieval; skipping")
 		}

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -80,7 +80,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 	defer cancel()
 
 	if len(args) != 1 {
-		return errors.New("exactly one argument expected")
+		return errorShouldDisplayUsage{errors.New("exactly one argument expected")}
 	}
 	if opts.raw && opts.format != "" {
 		return errors.New("raw output does not support format option")

--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -48,7 +48,7 @@ func layersCmd(global *globalOptions) *cobra.Command {
 func (opts *layersOptions) run(args []string, stdout io.Writer) (retErr error) {
 	fmt.Fprintln(os.Stderr, `DEPRECATED: skopeo layers is deprecated in favor of skopeo copy`)
 	if len(args) == 0 {
-		return errors.New("Usage: layers imageReference [layer...]")
+		return errorShouldDisplayUsage{errors.New("at least one argument expected")}
 	}
 	imageName := args[0]
 

--- a/cmd/skopeo/list_tags.go
+++ b/cmd/skopeo/list_tags.go
@@ -88,7 +88,7 @@ func parseDockerRepositoryReference(refString string) (types.ImageReference, err
 	}
 
 	if !reference.IsNameOnly(ref) {
-		return nil, errors.New(`No tag or digest allowed in reference`)
+		return nil, errors.New(`no tag or digest allowed in reference`)
 	}
 
 	// Checks ok, now return a reference. This is a hack because the tag listing code expects a full image reference even though the tag is ignored
@@ -101,7 +101,7 @@ func listDockerTags(ctx context.Context, sys *types.SystemContext, imgRef types.
 
 	tags, err := docker.GetRepositoryTags(ctx, sys, imgRef)
 	if err != nil {
-		return ``, nil, fmt.Errorf("Error listing repository tags: %w", err)
+		return ``, nil, fmt.Errorf("listing repository tags: %w", err)
 	}
 	return repositoryName, tags, nil
 }
@@ -163,7 +163,7 @@ func (opts *tagsOptions) run(args []string, stdout io.Writer) (retErr error) {
 	defer cancel()
 
 	if len(args) != 1 {
-		return errorShouldDisplayUsage{errors.New("Exactly one non-option argument expected")}
+		return errorShouldDisplayUsage{errors.New("exactly one non-option argument expected")}
 	}
 
 	sys, err := opts.image.newSystemContext()
@@ -173,7 +173,7 @@ func (opts *tagsOptions) run(args []string, stdout io.Writer) (retErr error) {
 
 	transport := alltransports.TransportFromImageName(args[0])
 	if transport == nil {
-		return fmt.Errorf("Invalid %q: does not specify a transport", args[0])
+		return fmt.Errorf("invalid %q: does not specify a transport", args[0])
 	}
 
 	var repositoryName string
@@ -185,7 +185,7 @@ func (opts *tagsOptions) run(args []string, stdout io.Writer) (retErr error) {
 			return err
 		}
 	} else {
-		return fmt.Errorf("Unsupported transport '%s' for tag listing. Only supported: %s",
+		return fmt.Errorf("unsupported transport '%s' for tag listing. Only supported: %s",
 			transport.Name(), supportedTransports(", "))
 	}
 

--- a/cmd/skopeo/list_tags_test.go
+++ b/cmd/skopeo/list_tags_test.go
@@ -62,7 +62,7 @@ func TestListTags(t *testing.T) {
 		{"a1", "a2"},
 	} {
 		out, err := runSkopeo(append([]string{"list-tags"}, args...)...)
-		assertTestFailed(t, out, err, "Exactly one non-option argument expected")
+		assertTestFailed(t, out, err, "exactly one non-option argument expected")
 	}
 
 	// FIXME: Much more test coverage

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -167,10 +167,11 @@ func main() {
 	rootCmd, _ := createApp()
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		exitCode := 1
 		if isNotFoundImageError(err) {
-			os.Exit(2)
+			exitCode = 2
 		}
-		os.Exit(1)
+		os.Exit(exitCode)
 	}
 }
 

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -50,11 +50,11 @@ func requireSubcommand(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		suggestions := cmd.SuggestionsFor(args[0])
 		if len(suggestions) == 0 {
-			return fmt.Errorf("Unrecognized command `%[1]s %[2]s`\nTry '%[1]s --help' for more information", cmd.CommandPath(), args[0])
+			return fmt.Errorf("unrecognized command `%[1]s %[2]s`\nTry '%[1]s --help' for more information", cmd.CommandPath(), args[0])
 		}
-		return fmt.Errorf("Unrecognized command `%[1]s %[2]s`\n\nDid you mean this?\n\t%[3]s\n\nTry '%[1]s --help' for more information", cmd.CommandPath(), args[0], strings.Join(suggestions, "\n\t"))
+		return fmt.Errorf("unrecognized command `%[1]s %[2]s`\n\nDid you mean this?\n\t%[3]s\n\nTry '%[1]s --help' for more information", cmd.CommandPath(), args[0], strings.Join(suggestions, "\n\t"))
 	}
-	return fmt.Errorf("Missing command '%[1]s COMMAND'\nTry '%[1]s --help' for more information", cmd.CommandPath())
+	return fmt.Errorf("missing command '%[1]s COMMAND'\nTry '%[1]s --help' for more information", cmd.CommandPath())
 }
 
 // createApp returns a cobra.Command, and the underlying globalOptions object, to be run or tested.

--- a/cmd/skopeo/manifest.go
+++ b/cmd/skopeo/manifest.go
@@ -32,11 +32,11 @@ func (opts *manifestDigestOptions) run(args []string, stdout io.Writer) error {
 
 	man, err := os.ReadFile(manifestPath)
 	if err != nil {
-		return fmt.Errorf("Error reading manifest from %s: %v", manifestPath, err)
+		return fmt.Errorf("reading manifest from %s: %w", manifestPath, err)
 	}
 	digest, err := manifest.Digest(man)
 	if err != nil {
-		return fmt.Errorf("Error computing digest: %v", err)
+		return fmt.Errorf("computing digest: %w", err)
 	}
 	fmt.Fprintf(stdout, "%s\n", digest)
 	return nil

--- a/cmd/skopeo/manifest.go
+++ b/cmd/skopeo/manifest.go
@@ -26,7 +26,7 @@ func manifestDigestCmd() *cobra.Command {
 
 func (opts *manifestDigestOptions) run(args []string, stdout io.Writer) error {
 	if len(args) != 1 {
-		return errors.New("Usage: skopeo manifest-digest manifest")
+		return errorShouldDisplayUsage{errors.New("exactly one argument expected")}
 	}
 	manifestPath := args[0]
 

--- a/cmd/skopeo/manifest_test.go
+++ b/cmd/skopeo/manifest_test.go
@@ -13,7 +13,7 @@ func TestManifestDigest(t *testing.T) {
 		{"a1", "a2"},
 	} {
 		out, err := runSkopeo(append([]string{"manifest-digest"}, args...)...)
-		assertTestFailed(t, out, err, "Usage")
+		assertTestFailed(t, out, err, "exactly one argument expected")
 	}
 
 	// Error reading manifest

--- a/cmd/skopeo/proxy_windows.go
+++ b/cmd/skopeo/proxy_windows.go
@@ -25,5 +25,5 @@ func proxyCmd(global *globalOptions) *cobra.Command {
 }
 
 func (opts *proxyOptions) run(args []string, stdout io.Writer) error {
-	return fmt.Errorf("This command is not supported on Windows")
+	return fmt.Errorf("this command is not supported on Windows")
 }

--- a/cmd/skopeo/signing.go
+++ b/cmd/skopeo/signing.go
@@ -33,8 +33,11 @@ func standaloneSignCmd() *cobra.Command {
 }
 
 func (opts *standaloneSignOptions) run(args []string, stdout io.Writer) error {
-	if len(args) != 3 || opts.output == "" {
-		return errors.New("Usage: skopeo standalone-sign manifest docker-reference key-fingerprint -o signature")
+	if len(args) != 3 {
+		return errorShouldDisplayUsage{errors.New("exactly three arguments expected")}
+	}
+	if opts.output == "" {
+		return errorShouldDisplayUsage{errors.New("--output must be specified")}
 	}
 	manifestPath := args[0]
 	dockerReference := args[1]
@@ -89,7 +92,7 @@ KEY-FINGERPRINTS can be a comma separated list of fingerprints, or "any" if you 
 
 func (opts *standaloneVerifyOptions) run(args []string, stdout io.Writer) error {
 	if len(args) != 4 {
-		return errors.New("Usage: skopeo standalone-verify manifest docker-reference key-fingerprint signature")
+		return errorShouldDisplayUsage{errors.New("exactly four arguments expected")}
 	}
 	manifestPath := args[0]
 	expectedDockerReference := args[1]
@@ -162,7 +165,7 @@ func untrustedSignatureDumpCmd() *cobra.Command {
 
 func (opts *untrustedSignatureDumpOptions) run(args []string, stdout io.Writer) error {
 	if len(args) != 1 {
-		return errors.New("Usage: skopeo untrusted-signature-dump-without-verification signature")
+		return errorShouldDisplayUsage{errors.New("exactly one argument expected")}
 	}
 	untrustedSignaturePath := args[0]
 

--- a/cmd/skopeo/signing.go
+++ b/cmd/skopeo/signing.go
@@ -42,12 +42,12 @@ func (opts *standaloneSignOptions) run(args []string, stdout io.Writer) error {
 
 	manifest, err := os.ReadFile(manifestPath)
 	if err != nil {
-		return fmt.Errorf("Error reading %s: %w", manifestPath, err)
+		return fmt.Errorf("reading %s: %w", manifestPath, err)
 	}
 
 	mech, err := signature.NewGPGSigningMechanism()
 	if err != nil {
-		return fmt.Errorf("Error initializing GPG: %w", err)
+		return fmt.Errorf("initializing GPG: %w", err)
 	}
 	defer mech.Close()
 
@@ -58,11 +58,11 @@ func (opts *standaloneSignOptions) run(args []string, stdout io.Writer) error {
 
 	signature, err := signature.SignDockerManifestWithOptions(manifest, dockerReference, mech, fingerprint, &signature.SignOptions{Passphrase: passphrase})
 	if err != nil {
-		return fmt.Errorf("Error creating signature: %w", err)
+		return fmt.Errorf("creating signature: %w", err)
 	}
 
 	if err := os.WriteFile(opts.output, signature, 0o644); err != nil {
-		return fmt.Errorf("Error writing signature to %s: %w", opts.output, err)
+		return fmt.Errorf("writing signature to %s: %w", opts.output, err)
 	}
 	return nil
 }
@@ -97,15 +97,15 @@ func (opts *standaloneVerifyOptions) run(args []string, stdout io.Writer) error 
 	signaturePath := args[3]
 
 	if opts.publicKeyFile == "" && len(expectedFingerprints) == 1 && expectedFingerprints[0] == "any" {
-		return fmt.Errorf("Cannot use any fingerprint without a public key file")
+		return fmt.Errorf("cannot use any fingerprint without a public key file")
 	}
 	unverifiedManifest, err := os.ReadFile(manifestPath)
 	if err != nil {
-		return fmt.Errorf("Error reading manifest from %s: %w", manifestPath, err)
+		return fmt.Errorf("reading manifest from %s: %w", manifestPath, err)
 	}
 	unverifiedSignature, err := os.ReadFile(signaturePath)
 	if err != nil {
-		return fmt.Errorf("Error reading signature from %s: %w", signaturePath, err)
+		return fmt.Errorf("reading signature from %s: %w", signaturePath, err)
 	}
 
 	var mech signature.SigningMechanism
@@ -113,16 +113,16 @@ func (opts *standaloneVerifyOptions) run(args []string, stdout io.Writer) error 
 	if opts.publicKeyFile != "" {
 		publicKeys, err := os.ReadFile(opts.publicKeyFile)
 		if err != nil {
-			return fmt.Errorf("Error reading public keys from %s: %w", opts.publicKeyFile, err)
+			return fmt.Errorf("reading public keys from %s: %w", opts.publicKeyFile, err)
 		}
 		mech, publicKeyfingerprints, err = signature.NewEphemeralGPGSigningMechanism(publicKeys)
 		if err != nil {
-			return fmt.Errorf("Error initializing GPG: %w", err)
+			return fmt.Errorf("initializing GPG: %w", err)
 		}
 	} else {
 		mech, err = signature.NewGPGSigningMechanism()
 		if err != nil {
-			return fmt.Errorf("Error initializing GPG: %w", err)
+			return fmt.Errorf("initializing GPG: %w", err)
 		}
 	}
 	defer mech.Close()
@@ -133,7 +133,7 @@ func (opts *standaloneVerifyOptions) run(args []string, stdout io.Writer) error 
 
 	sig, verificationFingerprint, err := signature.VerifyImageManifestSignatureUsingKeyIdentityList(unverifiedSignature, unverifiedManifest, expectedDockerReference, mech, expectedFingerprints)
 	if err != nil {
-		return fmt.Errorf("Error verifying signature: %w", err)
+		return fmt.Errorf("verifying signature: %w", err)
 	}
 
 	fmt.Fprintf(stdout, "Signature verified using fingerprint %s, digest %s\n", verificationFingerprint, sig.DockerManifestDigest)
@@ -168,12 +168,12 @@ func (opts *untrustedSignatureDumpOptions) run(args []string, stdout io.Writer) 
 
 	untrustedSignature, err := os.ReadFile(untrustedSignaturePath)
 	if err != nil {
-		return fmt.Errorf("Error reading untrusted signature from %s: %w", untrustedSignaturePath, err)
+		return fmt.Errorf("reading untrusted signature from %s: %w", untrustedSignaturePath, err)
 	}
 
 	untrustedInfo, err := signature.GetUntrustedSignatureInformationWithoutVerifying(untrustedSignature)
 	if err != nil {
-		return fmt.Errorf("Error decoding untrusted signature: %v", err)
+		return fmt.Errorf("decoding untrusted signature: %w", err)
 	}
 	untrustedOut, err := json.MarshalIndent(untrustedInfo, "", "    ")
 	if err != nil {

--- a/cmd/skopeo/signing_test.go
+++ b/cmd/skopeo/signing_test.go
@@ -45,17 +45,18 @@ func TestStandaloneSign(t *testing.T) {
 	for _, args := range [][]string{
 		{},
 		{"a1", "a2"},
-		{"a1", "a2", "a3"},
 		{"a1", "a2", "a3", "a4"},
 		{"-o", "o", "a1", "a2"},
 		{"-o", "o", "a1", "a2", "a3", "a4"},
 	} {
 		out, err := runSkopeo(append([]string{"standalone-sign"}, args...)...)
-		assertTestFailed(t, out, err, "Usage")
+		assertTestFailed(t, out, err, "exactly three arguments expected")
 	}
+	out, err := runSkopeo("standalone-sign", "a1", "a2", "a3")
+	assertTestFailed(t, out, err, "--output must be specified")
 
 	// Error reading manifest
-	out, err := runSkopeo("standalone-sign", "-o", "/dev/null",
+	out, err = runSkopeo("standalone-sign", "-o", "/dev/null",
 		"/this/does/not/exist", dockerReference, fixturesTestKeyFingerprint)
 	assertTestFailed(t, out, err, "/this/does/not/exist")
 
@@ -105,7 +106,7 @@ func TestStandaloneVerify(t *testing.T) {
 		{"a1", "a2", "a3", "a4", "a5"},
 	} {
 		out, err := runSkopeo(append([]string{"standalone-verify"}, args...)...)
-		assertTestFailed(t, out, err, "Usage")
+		assertTestFailed(t, out, err, "exactly four arguments expected")
 	}
 
 	// Error reading manifest
@@ -163,7 +164,7 @@ func TestUntrustedSignatureDump(t *testing.T) {
 		{"a1", "a2", "a3", "a4"},
 	} {
 		out, err := runSkopeo(append([]string{"untrusted-signature-dump-without-verification"}, args...)...)
-		assertTestFailed(t, out, err, "Usage")
+		assertTestFailed(t, out, err, "exactly one argument expected")
 	}
 
 	// Error reading manifest

--- a/cmd/skopeo/signing_test.go
+++ b/cmd/skopeo/signing_test.go
@@ -121,12 +121,12 @@ func TestStandaloneVerify(t *testing.T) {
 	// Error verifying signature
 	out, err = runSkopeo("standalone-verify", manifestPath,
 		dockerReference, fixturesTestKeyFingerprint, "fixtures/corrupt.signature")
-	assertTestFailed(t, out, err, "Error verifying signature")
+	assertTestFailed(t, out, err, "verifying signature")
 
 	// Error using any without a public key file
 	out, err = runSkopeo("standalone-verify", manifestPath,
 		dockerReference, "any", signaturePath)
-	assertTestFailed(t, out, err, "Cannot use any fingerprint without a public key file")
+	assertTestFailed(t, out, err, "cannot use any fingerprint without a public key file")
 
 	// Success
 	out, err = runSkopeo("standalone-verify", manifestPath,
@@ -173,7 +173,7 @@ func TestUntrustedSignatureDump(t *testing.T) {
 
 	// Error reading signature (input is not a signature)
 	out, err = runSkopeo("untrusted-signature-dump-without-verification", "fixtures/image.manifest.json")
-	assertTestFailed(t, out, err, "Error decoding untrusted signature")
+	assertTestFailed(t, out, err, "decoding untrusted signature")
 
 	// Success
 	for _, path := range []string{"fixtures/image.signature", "fixtures/corrupt.signature"} {

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -146,7 +146,7 @@ func newSourceConfig(yamlFile string) (sourceConfig, error) {
 	}
 	err = yaml.Unmarshal(source, &cfg)
 	if err != nil {
-		return cfg, fmt.Errorf("Failed to unmarshal %q: %w", yamlFile, err)
+		return cfg, fmt.Errorf("unmarshaling %q: %w", yamlFile, err)
 	}
 	return cfg, nil
 }
@@ -176,14 +176,14 @@ func destinationReference(destination string, transport string) (types.ImageRefe
 	case directory.Transport.Name():
 		_, err := os.Stat(destination)
 		if err == nil {
-			return nil, fmt.Errorf("Refusing to overwrite destination directory %q", destination)
+			return nil, fmt.Errorf("refusing to overwrite destination directory %q", destination)
 		}
 		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("Destination directory could not be used: %w", err)
+			return nil, fmt.Errorf("using destination directory: %w", err)
 		}
 		// the directory holding the image must be created here
 		if err = os.MkdirAll(destination, 0o755); err != nil {
-			return nil, fmt.Errorf("Error creating directory for image %s: %w", destination, err)
+			return nil, fmt.Errorf("creating directory for image %s: %w", destination, err)
 		}
 		imageTransport = directory.Transport
 	default:
@@ -193,7 +193,7 @@ func destinationReference(destination string, transport string) (types.ImageRefe
 
 	destRef, err := imageTransport.ParseReference(destination)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot obtain a valid image reference for transport %q and reference %q: %w", imageTransport.Name(), destination, err)
+		return nil, fmt.Errorf("obtaining a valid image reference for transport %q and reference %q: %w", imageTransport.Name(), destination, err)
 	}
 
 	return destRef, nil
@@ -212,7 +212,7 @@ func getImageTags(ctx context.Context, sysCtx *types.SystemContext, repoRef refe
 	}
 	tags, err := docker.GetRepositoryTags(ctx, sysCtx, dockerRef)
 	if err != nil {
-		return nil, fmt.Errorf("Error determining repository tags for repo %s: %w", name, err)
+		return nil, fmt.Errorf("determining repository tags for repo %s: %w", name, err)
 	}
 
 	return tags, nil
@@ -237,7 +237,7 @@ func imagesToCopyFromRepo(sys *types.SystemContext, repoRef reference.Named) ([]
 		}
 		ref, err := docker.NewReference(taggedRef)
 		if err != nil {
-			return nil, fmt.Errorf("Cannot obtain a valid image reference for transport %q and reference %s: %w", docker.Transport.Name(), taggedRef.String(), err)
+			return nil, fmt.Errorf("obtaining a valid image reference for transport %q and reference %s: %w", docker.Transport.Name(), taggedRef.String(), err)
 		}
 		sourceReferences = append(sourceReferences, ref)
 	}
@@ -258,7 +258,7 @@ func imagesToCopyFromDir(dirPath string) ([]types.ImageReference, error) {
 			dirname := filepath.Dir(path)
 			ref, err := directory.Transport.ParseReference(dirname)
 			if err != nil {
-				return fmt.Errorf("Cannot obtain a valid image reference for transport %q and reference %q: %w", directory.Transport.Name(), dirname, err)
+				return fmt.Errorf("obtaining a valid image reference for transport %q and reference %q: %w", directory.Transport.Name(), dirname, err)
 			}
 			sourceReferences = append(sourceReferences, ref)
 			return filepath.SkipDir
@@ -267,7 +267,7 @@ func imagesToCopyFromDir(dirPath string) ([]types.ImageReference, error) {
 	})
 	if err != nil {
 		return sourceReferences,
-			fmt.Errorf("Error walking the path %q: %w", dirPath, err)
+			fmt.Errorf("walking the path %q: %w", dirPath, err)
 	}
 
 	return sourceReferences, nil
@@ -505,14 +505,14 @@ func imagesToCopy(source string, transport string, sourceCtx *types.SystemContex
 		}
 		named, err := reference.ParseNormalizedNamed(source) // May be a repository or an image.
 		if err != nil {
-			return nil, fmt.Errorf("Cannot obtain a valid image reference for transport %q and reference %q: %w", docker.Transport.Name(), source, err)
+			return nil, fmt.Errorf("obtaining a valid image reference for transport %q and reference %q: %w", docker.Transport.Name(), source, err)
 		}
 		imageTagged := !reference.IsNameOnly(named)
 		slog.Info("Tag presence check", "imagename", source, "tagged", imageTagged)
 		if imageTagged {
 			srcRef, err := docker.NewReference(named)
 			if err != nil {
-				return nil, fmt.Errorf("Cannot obtain a valid image reference for transport %q and reference %q: %w", docker.Transport.Name(), named.String(), err)
+				return nil, fmt.Errorf("obtaining a valid image reference for transport %q and reference %q: %w", docker.Transport.Name(), named.String(), err)
 			}
 			desc.ImageRefs = []types.ImageReference{srcRef}
 		} else {
@@ -521,7 +521,7 @@ func imagesToCopy(source string, transport string, sourceCtx *types.SystemContex
 				return descriptors, err
 			}
 			if len(desc.ImageRefs) == 0 {
-				return descriptors, fmt.Errorf("No images to sync found in %q", source)
+				return descriptors, fmt.Errorf("no images to sync found in %q", source)
 			}
 		}
 		descriptors = append(descriptors, desc)
@@ -532,7 +532,7 @@ func imagesToCopy(source string, transport string, sourceCtx *types.SystemContex
 		}
 
 		if _, err := os.Stat(source); err != nil {
-			return descriptors, fmt.Errorf("Invalid source directory specified: %w", err)
+			return descriptors, fmt.Errorf("invalid source directory specified: %w", err)
 		}
 		desc.DirBasePath = source
 		var err error
@@ -541,7 +541,7 @@ func imagesToCopy(source string, transport string, sourceCtx *types.SystemContex
 			return descriptors, err
 		}
 		if len(desc.ImageRefs) == 0 {
-			return descriptors, fmt.Errorf("No images to sync found in %q", source)
+			return descriptors, fmt.Errorf("no images to sync found in %q", source)
 		}
 		descriptors = append(descriptors, desc)
 
@@ -553,7 +553,7 @@ func imagesToCopy(source string, transport string, sourceCtx *types.SystemContex
 		for registryName, registryConfig := range cfg {
 			descs, err := imagesToCopyFromRegistry(registryName, registryConfig, *sourceCtx)
 			if err != nil {
-				return descriptors, fmt.Errorf("Failed to retrieve list of images from registry %q: %w", registryName, err)
+				return descriptors, fmt.Errorf("retrieving list of images from registry %q: %w", registryName, err)
 			}
 			descriptors = append(descriptors, descs...)
 		}
@@ -564,13 +564,13 @@ func imagesToCopy(source string, transport string, sourceCtx *types.SystemContex
 
 func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 	if len(args) != 2 {
-		return errorShouldDisplayUsage{errors.New("Exactly two arguments expected")}
+		return errorShouldDisplayUsage{errors.New("exactly two arguments expected")}
 	}
 	opts.deprecatedTLSVerify.warnIfUsed([]string{"--src-tls-verify", "--dest-tls-verify"})
 
 	policyContext, err := opts.global.getPolicyContext()
 	if err != nil {
-		return fmt.Errorf("Error loading trust policy: %w", err)
+		return fmt.Errorf("loading trust policy: %w", err)
 	}
 	defer func() {
 		if err := policyContext.Destroy(); err != nil {
@@ -580,14 +580,14 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 
 	// validate source and destination options
 	if len(opts.source) == 0 {
-		return errors.New("A source transport must be specified")
+		return errors.New("a source transport must be specified")
 	}
 	if !slices.Contains([]string{docker.Transport.Name(), directory.Transport.Name(), "yaml"}, opts.source) {
 		return fmt.Errorf("%q is not a valid source transport", opts.source)
 	}
 
 	if len(opts.destination) == 0 {
-		return errors.New("A destination transport must be specified")
+		return errors.New("a destination transport must be specified")
 	}
 	if !slices.Contains([]string{docker.Transport.Name(), directory.Transport.Name()}, opts.destination) {
 		return fmt.Errorf("%q is not a valid destination transport", opts.destination)
@@ -646,7 +646,7 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 	if opts.digestFile != "" && !opts.dryRun {
 		digestFile, err = os.OpenFile(opts.digestFile, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
-			return fmt.Errorf("Error creating digest file: %w", err)
+			return fmt.Errorf("creating digest file: %w", err)
 		}
 		defer func() {
 			if err := digestFile.Close(); err != nil {
@@ -692,7 +692,7 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 					return err
 				}, opts.retryOpts); err != nil {
 					if !opts.keepGoing {
-						return fmt.Errorf("Error copying ref %q: %w", transports.ImageName(ref), err)
+						return fmt.Errorf("copying ref %q: %w", transports.ImageName(ref), err)
 					}
 					// log the error, keep a note that there was a failure and move on to the next
 					// image ref
@@ -708,7 +708,7 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 					}
 					outputStr := fmt.Sprintf("%s %s", manifestDigest.String(), transports.ImageName(destRef))
 					if _, err = digestFile.WriteString(outputStr + "\n"); err != nil {
-						return fmt.Errorf("Failed to write digest to file %q: %w", opts.digestFile, err)
+						return fmt.Errorf("writing digest to file %q: %w", opts.digestFile, err)
 					}
 				}
 			}
@@ -725,5 +725,5 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 	if !errorsPresent {
 		return nil
 	}
-	return errors.New("Sync failed due to previous reported error(s) for one or more images")
+	return errors.New("sync failed due to previous reported error(s) for one or more images")
 }

--- a/cmd/skopeo/sync_test.go
+++ b/cmd/skopeo/sync_test.go
@@ -54,7 +54,7 @@ func TestSync(t *testing.T) {
 		{"a1", "a2", "a3"},
 	} {
 		out, err := runSkopeo(append([]string{"sync"}, args...)...)
-		assertTestFailed(t, out, err, "Exactly two arguments expected")
+		assertTestFailed(t, out, err, "exactly two arguments expected")
 	}
 
 	// FIXME: Much more test coverage

--- a/cmd/skopeo/unshare_linux.go
+++ b/cmd/skopeo/unshare_linux.go
@@ -25,10 +25,10 @@ func maybeReexec() error {
 	// if we already have the capabilities we need.
 	capabilities, err := capability.NewPid2(0)
 	if err != nil {
-		return fmt.Errorf("error reading the current capabilities sets: %w", err)
+		return fmt.Errorf("reading the current capabilities sets: %w", err)
 	}
 	if err := capabilities.Load(); err != nil {
-		return fmt.Errorf("error loading the current capabilities sets: %w", err)
+		return fmt.Errorf("loading the current capabilities sets: %w", err)
 	}
 	if slices.ContainsFunc(neededCapabilities, func(cap capability.Cap) bool {
 		return !capabilities.Get(capability.EFFECTIVE, cap)

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -370,7 +370,7 @@ func (opts *sharedCopyOptions) copyOptions(stdout io.Writer) (*copy.Options, fun
 	}
 
 	if opts.removeSignatures && opts.removeListSignatures {
-		return nil, nil, fmt.Errorf("Only one of --remove-signatures and --remove-list-signatures can be specified")
+		return nil, nil, fmt.Errorf("only one of --remove-signatures and --remove-list-signatures can be specified")
 	}
 
 	// c/image/copy.Image does allow creating both simple signing and sigstore signatures simultaneously,
@@ -388,7 +388,7 @@ func (opts *sharedCopyOptions) copyOptions(stdout io.Writer) (*copy.Options, fun
 			count++
 		}
 		if count > 1 {
-			return nil, nil, fmt.Errorf("Only one of --sign-by, --sign-by-sq-fingerprint and --sign-by-sigstore-private-key can be used with --sign-passphrase-file")
+			return nil, nil, fmt.Errorf("only one of --sign-by, --sign-by-sq-fingerprint and --sign-by-sigstore-private-key can be used with --sign-passphrase-file")
 		}
 	}
 	// Simple signing does not really allow empty but present passphrases — but for sigstore, cosign does support creating keys encrypted with an empty passphrase;
@@ -437,7 +437,7 @@ func (opts *sharedCopyOptions) copyOptions(stdout io.Writer) (*copy.Options, fun
 			Stdout: stdout,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("Error using --sign-by-sigstore: %w", err)
+			return nil, nil, fmt.Errorf("using --sign-by-sigstore: %w", err)
 		}
 		signers = append(signers, signer)
 	}
@@ -450,7 +450,7 @@ func (opts *sharedCopyOptions) copyOptions(stdout io.Writer) (*copy.Options, fun
 		}
 		signer, err := simplesequoia.NewSigner(sqOpts...) //nolint:staticcheck // SA4023: without the containers_image_sequoia build tag, this always fails.
 		if err != nil {                                   //nolint:staticcheck // SA4023 … and staticcheck reports both the comparison and the "related" call.
-			return nil, nil, fmt.Errorf("Error using --sign-by-sq-fingerprint: %w", err)
+			return nil, nil, fmt.Errorf("using --sign-by-sq-fingerprint: %w", err)
 		}
 		signers = append(signers, signer)
 	}
@@ -556,13 +556,13 @@ func adjustUsage(c *cobra.Command) {
 func promptForPassphrase(privateKeyFile string, stdin, stdout *os.File) (string, error) {
 	stdinFd := int(stdin.Fd())
 	if !term.IsTerminal(stdinFd) {
-		return "", fmt.Errorf("Cannot prompt for a passphrase for key %s, standard input is not a TTY", privateKeyFile)
+		return "", fmt.Errorf("cannot prompt for a passphrase for key %s, standard input is not a TTY", privateKeyFile)
 	}
 
 	fmt.Fprintf(stdout, "Passphrase for key %s: ", privateKeyFile)
 	passphrase, err := term.ReadPassword(stdinFd)
 	if err != nil {
-		return "", fmt.Errorf("Error reading password: %w", err)
+		return "", fmt.Errorf("reading password: %w", err)
 	}
 	fmt.Fprintf(stdout, "\n")
 	return string(passphrase), nil

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -1195,7 +1195,7 @@ func (s *copySuite) TestCopyVerifyingMirroredSignatures() {
 		"--policy", policy, "--registries.d", registriesDir, "--registries-conf", "fixtures/registries.conf", "copy", "--src-tls-verify=false", regPrefix+"primary:mirror-signed", dirDest)
 
 	// Fail if we specify an unqualified identity
-	assertSkopeoFails(t, ".*Could not parse --sign-identity: repository name must be canonical.*",
+	assertSkopeoFails(t, ".*parsing --sign-identity: repository name must be canonical.*",
 		"--registries.d", registriesDir, "copy", "--src-tls-verify=false", "--dest-tls-verify=false", "--sign-by=personal@example.com", "--sign-identity=this-is-not-fully-specified", regPrefix+"primary:unsigned", regPrefix+"mirror:primary-signed")
 
 	// Create a signature for mirroring-primary:primary-signed without pushing there.

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -232,7 +232,7 @@ func (s *syncSuite) TestDirIsNotOverwritten() {
 	require.NoError(t, err)
 
 	// sync local registry image to dir, not scoped
-	assertSkopeoFails(t, ".*Refusing to overwrite destination directory.*", "sync", "--src-tls-verify=false", "--src", "docker", "--dest", "dir", path.Join(v2DockerRegistryURL, reference.Path(imageRef.DockerReference())), dir1)
+	assertSkopeoFails(t, ".*refusing to overwrite destination directory.*", "sync", "--src-tls-verify=false", "--src", "docker", "--dest", "dir", path.Join(v2DockerRegistryURL, reference.Path(imageRef.DockerReference())), dir1)
 
 	// sync local registry image to dir, scoped
 	imageRef, err = docker.ParseReference(fmt.Sprintf("//%s", path.Join(v2DockerRegistryURL, reference.Path(imageRef.DockerReference()))))
@@ -556,10 +556,10 @@ func (s *syncSuite) TestFailsNoSourceImages() {
 	t := s.T()
 	tmpDir := t.TempDir()
 
-	assertSkopeoFails(t, ".*No images to sync found in .*",
+	assertSkopeoFails(t, ".*no images to sync found in .*",
 		"sync", "--scoped", "--dest-tls-verify=false", "--src", "dir", "--dest", "docker", tmpDir, v2DockerRegistryURL)
 
-	assertSkopeoFails(t, ".*Error determining repository tags for repo docker.io/library/hopefully_no_images_will_ever_be_called_like_this: fetching tags list: requested access to the resource is denied.*",
+	assertSkopeoFails(t, ".*determining repository tags for repo docker.io/library/hopefully_no_images_will_ever_be_called_like_this: fetching tags list: requested access to the resource is denied.*",
 		"sync", "--scoped", "--dest-tls-verify=false", "--src", "docker", "--dest", "docker", "hopefully_no_images_will_ever_be_called_like_this", v2DockerRegistryURL)
 }
 


### PR DESCRIPTION
Per https://github.com/podman-container-tools/skopeo/pull/2958#discussion_r3927198660:

Change the final error from current
```
FATA[000t] Error doing …
```
or log/slog
```
(optional timestamp) ERROR Error doing …
```
to Podman-like
```
Error: doing …
```

See individual commit messages for details.